### PR TITLE
docs: fix outdated information in README.md

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.8.0"
 edition = "2024"
 description = "CLI tool for Microsoft Defender for Endpoint API"
 license = "MIT"
-repository = "https://github.com/hiboma/microsoft-defender-for-endpoint-cli"
+repository = "https://github.com/hiboma/mde-cli"
 
 [[bin]]
 name = "mde-cli"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The binary will be at `target/release/mde-cli`.
 | `MDE_CLIENT_ID` | Azure AD application (client) ID |
 | `MDE_CLIENT_SECRET` | Azure AD client secret |
 | `MDE_ACCESS_TOKEN` | Pre-obtained access token (skips OAuth2 flow) |
-| `MDE_OUTPUT_FORMAT` | Output format: `json` (default) or `table` |
+| `MDE_OUTPUT_FORMAT` | Output format: `json` (default), `json-minify`, or `table` |
 
 ### Config File
 
@@ -87,19 +87,19 @@ export MDE_CLIENT_SECRET="your-secret"
 
 ```bash
 mde-cli alerts list
-mde-cli alerts get --id <alert-id>
-mde-cli alerts update --id <alert-id> --status resolved
-mde-cli alerts files --id <alert-id>
-mde-cli alerts ips --id <alert-id>
-mde-cli alerts domains --id <alert-id>
+mde-cli alerts get <alert-id>
+mde-cli alerts update <alert-id> --status resolved
+mde-cli alerts files <alert-id>
+mde-cli alerts ips <alert-id>
+mde-cli alerts domains <alert-id>
 ```
 
 ### Incidents
 
 ```bash
 mde-cli incidents list
-mde-cli incidents get --id <incident-id>
-mde-cli incidents update --id <incident-id> --status resolved
+mde-cli incidents get <incident-id>
+mde-cli incidents update <incident-id> --status resolved
 ```
 
 ### Advanced Hunting
@@ -112,9 +112,9 @@ mde-cli hunting run --query "DeviceProcessEvents | take 10"
 
 ```bash
 mde-cli machines list
-mde-cli machines get --id <machine-id>
-mde-cli machines timeline --id <machine-id>
-mde-cli machines logon-users --id <machine-id>
+mde-cli machines get <machine-id>
+mde-cli machines timeline <machine-id>
+mde-cli machines logon-users <machine-id>
 ```
 
 ### Agent Mode (Credential Isolation)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A command-line tool for interacting with the [Microsoft Defender for Endpoint AP
 - **Advanced Hunting** - Run KQL queries against the advanced hunting API
 - **Machines** - List, get machine details, view timelines and logon users
 - **Agent Mode** - Credential isolation for use with LLM agents (ssh-agent pattern)
-- **OAuth2 Authentication** - Device code flow and client credentials
+- **OAuth2 Authentication** - Browser login (Authorization Code Flow with PKCE) and client credentials
 
 ## Installation
 
@@ -22,8 +22,8 @@ cargo install --path .
 ### Build from source
 
 ```bash
-git clone https://github.com/hiboma/microsoft-defender-for-endpoint-cli.git
-cd microsoft-defender-for-endpoint-cli
+git clone https://github.com/hiboma/mde-cli.git
+cd mde-cli
 cargo build --release
 ```
 
@@ -43,10 +43,10 @@ The binary will be at `target/release/mde-cli`.
 
 ### Config File
 
-You can also set credentials in `~/.config/mde/config.toml`:
+You can also set credentials in `~/.config/mde/credentials.toml`:
 
 ```toml
-[auth]
+[credentials]
 tenant_id = "your-tenant-id"
 client_id = "your-client-id"
 client_secret = "your-client-secret"
@@ -71,8 +71,11 @@ client_secret = "your-client-secret"
 ### Authentication
 
 ```bash
-# Device code flow (interactive)
-mde-cli auth device-code
+# Browser login (Authorization Code Flow with PKCE)
+mde-cli auth login
+
+# Show token for client_credentials flow (CI use)
+mde-cli auth token
 
 # Client credentials (non-interactive)
 export MDE_TENANT_ID="your-tenant-id"
@@ -96,6 +99,7 @@ mde-cli alerts domains --id <alert-id>
 ```bash
 mde-cli incidents list
 mde-cli incidents get --id <incident-id>
+mde-cli incidents update --id <incident-id> --status resolved
 ```
 
 ### Advanced Hunting
@@ -138,6 +142,9 @@ See [ADR-0001](docs/adr/0001-agent-mode-for-credential-isolation.md) for the des
 ```bash
 # JSON output (default)
 mde-cli alerts list --output json
+
+# Minified JSON output
+mde-cli alerts list --output json-minify
 
 # Table output
 mde-cli alerts list --output table


### PR DESCRIPTION
## Summary

Fix multiple outdated and incorrect descriptions in README.md so that the documentation accurately reflects the current state of the codebase.

## Why

Several sections of README.md had fallen out of sync with the actual source code, including a renamed repository URL, incorrect config file name, non-existent CLI commands, and missing features. This could confuse new users trying to set up and use the tool.

## Changes

- Update repository URL from `microsoft-defender-for-endpoint-cli` to `mde-cli` (README.md and Cargo.toml)
- Fix config file name from `config.toml` to `credentials.toml` and section from `[auth]` to `[credentials]`
- Replace non-existent `auth device-code` with actual `auth login` / `auth token` commands
- Update OAuth2 feature description to reflect browser-based PKCE flow
- Fix `--id` flags to positional arguments for alerts, incidents, and machines subcommands
- Add missing `incidents update` command example
- Add missing `json-minify` output format to examples and environment variable table

🤖 Generated with [Claude Code](https://claude.com/claude-code)