### PR TITLE
feat(cli): add completion subcommand for shell completion scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +391,7 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
+ "clap_complete",
  "dirs",
  "dotenvy",
  "gag",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/lib.rs"
 arboard = "3"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive", "env"] }
+clap_complete = "4"
 dirs = "6"
 dotenvy = "0.15"
 gag = "1"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,6 +6,7 @@ pub mod incidents;
 pub mod machines;
 
 use clap::{Parser, Subcommand};
+use clap_complete::Shell;
 
 use crate::output::OutputFormat;
 
@@ -32,6 +33,7 @@ Authentication:
   agent              Manage the credential isolation agent
 
 Other:
+  completion         Generate shell completion script
   help               Print this message or the help of the given subcommand(s)
 
 {all-args}{after-help}"
@@ -137,6 +139,12 @@ pub enum Commands {
         #[command(subcommand)]
         command: agent::AgentCommand,
     },
+    /// Generate shell completion script
+    #[command(hide = true)]
+    Completion {
+        /// Shell to generate completion for
+        shell: Shell,
+    },
 }
 
 impl Commands {
@@ -148,6 +156,7 @@ impl Commands {
             Commands::Hunting { .. } => "hunting",
             Commands::Machines { .. } => "machines",
             Commands::Agent { .. } => "agent",
+            Commands::Completion { .. } => "completion",
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,6 @@
 use clap::{CommandFactory, Parser};
+use clap_complete::generate;
+use std::io;
 use std::path::PathBuf;
 use std::process;
 
@@ -98,6 +100,14 @@ async fn run(cli: Cli, credentials: MdeCredentials) -> Result<(), AppError> {
             return Ok(());
         }
     };
+
+    // Handle completion generation (no credentials required).
+    if let Commands::Completion { shell } = &command {
+        let mut cmd = Cli::command();
+        let bin_name = cmd.get_name().to_string();
+        generate(*shell, &mut cmd, bin_name, &mut io::stdout());
+        return Ok(());
+    }
 
     // Handle agent subcommands.
     if let Commands::Agent { command: agent_cmd } = &command {
@@ -319,6 +329,7 @@ fn requires_agent_routing(command: &Commands) -> bool {
         Commands::Machines { command } => command.is_some(),
         Commands::Auth { command } => command.is_some(),
         Commands::Agent { .. } => false, // agent commands are handled separately
+        Commands::Completion { .. } => false, // handled locally
     }
 }
 

--- a/tests/completion.rs
+++ b/tests/completion.rs
@@ -1,0 +1,53 @@
+//! Integration tests for `mde-cli completion <SHELL>`.
+//!
+//! The completion subcommand must be runnable without any credentials or
+//! agent context — installing completions is something users do before
+//! authenticating. These tests guard the early-return path in `run()` so a
+//! future refactor cannot accidentally require credentials to print a
+//! completion script.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn mde_cmd() -> Command {
+    let mut cmd = Command::cargo_bin("mde-cli").unwrap();
+    cmd.env_remove("MDE_TENANT_ID")
+        .env_remove("MDE_CLIENT_ID")
+        .env_remove("MDE_CLIENT_SECRET")
+        .env_remove("MDE_ACCESS_TOKEN")
+        .env_remove("MDE_AGENT_TOKEN")
+        .env_remove("MDE_AGENT_SOCKET");
+    cmd
+}
+
+#[test]
+fn completion_zsh_emits_compdef_header() {
+    mde_cmd()
+        .args(["completion", "zsh"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("#compdef mde-cli"));
+}
+
+#[test]
+fn completion_bash_emits_function_definition() {
+    mde_cmd()
+        .args(["completion", "bash"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("_mde-cli()"));
+}
+
+#[test]
+fn completion_without_shell_argument_fails() {
+    mde_cmd()
+        .arg("completion")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("<SHELL>"));
+}
+
+#[test]
+fn completion_rejects_unknown_shell() {
+    mde_cmd().args(["completion", "tcsh"]).assert().failure();
+}


### PR DESCRIPTION
## Motivation

Users of `mde-cli` currently have no way to install shell completion for commands, subcommands, and global flags. This PR adds a `mde-cli completion <SHELL>` subcommand that prints a ready-to-install completion script to stdout, so users can get interactive tab completion in their shell of choice.

## Why

`mde-cli` has a non-trivial command surface (`alerts`, `incidents`, `hunting`, `machines`, `auth`, `agent`, plus global flags like `--output`, `--raw`, `--tenant-id`, `--no-agent`). Tab completion reduces typos and speeds up exploration, especially for new users who are still learning the command structure. Generating completion scripts at runtime from the canonical clap definition is the standard Rust CLI approach and keeps the scripts always in sync with the CLI.

## How

- Added `clap_complete = \"4\"` as a dependency.
- Added a new `Commands::Completion { shell: clap_complete::Shell }` variant. The `Shell` enum gives us zsh, bash, fish, PowerShell, and elvish for free, and rejects unknown shell names at parse time.
- Wired the handler at the top of `run()`, before agent routing and before any credential-requiring code path, so installing completions does not require credentials or a running agent.
- `requires_agent_routing` returns `false` for `Completion` to make the intent explicit.
- Added `tests/completion.rs` with smoke tests that exercise the subcommand with all MDE env vars cleared, guarding the early-return path from future regressions.

## Usage

```zsh
# zsh
mde-cli completion zsh > \"\${fpath[1]}/_mde-cli\"

# bash
mde-cli completion bash > ~/.local/share/bash-completion/completions/mde-cli

# fish
mde-cli completion fish > ~/.config/fish/completions/mde-cli.fish
```

## Known limitation

`mde-cli completion fish | head` may surface a `BrokenPipe` panic from `clap_complete` 4.6's fish generator when the consumer closes the pipe early. The normal redirect-to-file usage shown above is unaffected. This is an upstream behavior and is out of scope for this PR.

## Test plan

- [x] `cargo build`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --test completion` (4 new tests pass)
- [x] Manually verified `mde-cli completion zsh|bash|fish` produces valid-looking scripts and `mde-cli completion` without an argument errors with `<SHELL>` required

🤖 Generated with [Claude Code](https://claude.com/claude-code)