### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "defender-for-endpoint-cli"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "arboard",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "defender-for-endpoint-cli"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 description = "CLI tool for Microsoft Defender for Endpoint API"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version from 0.8.0 to 0.9.0
- Minor bump because a new `completion` subcommand (#40) was added since v0.8.0

## Changes since v0.8.0
- feat(cli): add completion subcommand for shell completion scripts (#40)
- fix: address code scanning alerts for Scorecard compliance (#38)
- docs: fix outdated information in README.md (#39)
- ci: update codeql-action/upload-sarif from v3 to v4 (#37)

## Test plan
- [ ] CI (check, clippy, fmt, test) passes
- [ ] After merge, push the `v0.9.0` tag and confirm the release workflow builds multi-platform binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)