### PR TITLE
feat(indicators): add indicators subcommand for managing MDE indicators

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,14 @@ cargo fmt                # Format
 - `src/config/` - Configuration file handling
 - `src/error.rs` - Error types
 
+### Indicators
+
+- `indicators` subcommand manages MDE Indicators API (`/api/indicators`)
+- Supports `list`, `create`, `delete` operations
+- `create` accepts indicatorType (FileSha256, FileSha1, FileMd5, CertificateThumbprint, IpAddress, DomainName, Url) and action (Allowed, Alert, AlertAndBlock, Block)
+- Uses `securitycenter` scope, same as alerts/machines
+- Registered in agent command whitelist (`agent/security.rs`)
+
 ### Shared Mode
 
 - `mde-cli agent start --shared` writes session info to `~/.local/share/mde-cli/session.json`

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A command-line tool for interacting with the [Microsoft Defender for Endpoint AP
 - **Incidents** - List, get, and update incidents (via Microsoft Graph API)
 - **Advanced Hunting** - Run KQL queries against the advanced hunting API
 - **Machines** - List, get machine details, view timelines and logon users
+- **Indicators** - Create, list, and delete indicators (exclusions/blocks)
 - **Agent Mode** - Credential isolation for use with LLM agents (ssh-agent pattern)
 - **OAuth2 Authentication** - Browser login (Authorization Code Flow with PKCE) and client credentials
 
@@ -63,6 +64,7 @@ client_secret = "your-client-secret"
 | `Machine.Read.All` | Application | Read machine info |
 | `ThreatHunting.Read.All` | Application | Run advanced hunting queries (Graph API) |
 | `Incident.Read.All` | Delegated | Read incidents (Graph API) |
+| `Ti.ReadWrite` | Application | Manage indicators (create/delete) |
 
 3. Create a client secret under **Certificates & secrets**
 
@@ -117,6 +119,26 @@ mde-cli machines timeline <machine-id>
 mde-cli machines logon-users <machine-id>
 ```
 
+### Indicators
+
+```bash
+# List indicators
+mde-cli indicators list
+
+# List indicators filtered by type
+mde-cli indicators list --indicator-type FileSha256
+
+# Create an exclusion (allow) indicator for a file hash
+mde-cli indicators create <SHA256> \
+  --indicator-type FileSha256 \
+  --action Allowed \
+  --title "FP exclusion" \
+  --no-alert
+
+# Delete an indicator by ID
+mde-cli indicators delete <indicator-id>
+```
+
 ### Agent Mode (Credential Isolation)
 
 Agent mode isolates credentials from the process that invokes `mde-cli` commands. This is useful when running under LLM agents (e.g., Claude Code) where you want to prevent credential leakage via prompt injection.
@@ -157,7 +179,7 @@ mde-cli alerts list --raw
 
 | Subcommand | Base URL | Scope |
 |---|---|---|
-| `alerts`, `machines` | `https://api.security.microsoft.com` | `https://api.securitycenter.microsoft.com/.default` |
+| `alerts`, `machines`, `indicators` | `https://api.security.microsoft.com` | `https://api.securitycenter.microsoft.com/.default` |
 | `hunting`, `incidents` | `https://graph.microsoft.com` | `https://graph.microsoft.com/.default` |
 
 ## License

--- a/src/agent/security.rs
+++ b/src/agent/security.rs
@@ -19,7 +19,7 @@ impl CommandWhitelist {
 
     /// Create a default whitelist allowing all mde resource commands.
     pub fn default_mde() -> Self {
-        let allowed = ["alerts", "incidents", "hunting", "machines"]
+        let allowed = ["alerts", "incidents", "hunting", "machines", "indicators"]
             .iter()
             .map(|s| s.to_string())
             .collect();
@@ -289,6 +289,7 @@ mod tests {
         assert!(wl.is_allowed("incidents"));
         assert!(wl.is_allowed("hunting"));
         assert!(wl.is_allowed("machines"));
+        assert!(wl.is_allowed("indicators"));
         assert!(!wl.is_allowed("unknown"));
         assert!(!wl.is_allowed(""));
     }

--- a/src/cli/indicators.rs
+++ b/src/cli/indicators.rs
@@ -1,0 +1,66 @@
+use clap::{Args, Subcommand};
+
+#[derive(Subcommand)]
+pub enum IndicatorsCommand {
+    /// List indicators
+    List(ListArgs),
+    /// Create an indicator
+    Create(CreateArgs),
+    /// Delete an indicator by ID
+    Delete(DeleteArgs),
+}
+
+#[derive(Args)]
+pub struct ListArgs {
+    /// Maximum number of results
+    #[arg(long, default_value = "50")]
+    pub top: u32,
+
+    /// Filter by indicatorType: FileSha256, FileSha1, FileMd5, CertificateThumbprint, IpAddress, DomainName, Url
+    #[arg(long)]
+    pub indicator_type: Option<String>,
+
+    /// Filter by action: Allowed, Alert, AlertAndBlock, Block
+    #[arg(long)]
+    pub action: Option<String>,
+}
+
+#[derive(Args)]
+pub struct CreateArgs {
+    /// Indicator value (e.g. SHA256 hash, IP address, domain name)
+    pub indicator_value: String,
+
+    /// Indicator type: FileSha256, FileSha1, FileMd5, CertificateThumbprint, IpAddress, DomainName, Url
+    #[arg(long)]
+    pub indicator_type: String,
+
+    /// Action: Allowed, Alert, AlertAndBlock, Block
+    #[arg(long)]
+    pub action: String,
+
+    /// Title (short description)
+    #[arg(long)]
+    pub title: String,
+
+    /// Description
+    #[arg(long)]
+    pub description: Option<String>,
+
+    /// Severity: Informational, Low, Medium, High
+    #[arg(long)]
+    pub severity: Option<String>,
+
+    /// Suppress alert generation for this indicator
+    #[arg(long)]
+    pub no_alert: bool,
+
+    /// Expiration time in ISO 8601 format (e.g. 2026-12-31T00:00:00Z)
+    #[arg(long)]
+    pub expiration_time: Option<String>,
+}
+
+#[derive(Args)]
+pub struct DeleteArgs {
+    /// Indicator ID
+    pub id: u64,
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,6 +3,7 @@ pub mod alerts;
 pub mod auth;
 pub mod hunting;
 pub mod incidents;
+pub mod indicators;
 pub mod machines;
 
 use clap::{Parser, Subcommand};
@@ -23,10 +24,11 @@ use crate::output::OutputFormat;
 {usage-heading} {name} [OPTIONS] [COMMAND]
 
 Resources:
-  alerts [alert]      Manage alerts
-  incidents [incident] Manage incidents
-  hunting [hunt]      Run advanced hunting queries
-  machines [machine]  Manage machines (devices)
+  alerts [alert]        Manage alerts
+  incidents [incident]  Manage incidents
+  hunting [hunt]        Run advanced hunting queries
+  machines [machine]    Manage machines (devices)
+  indicators [indicator] Manage indicators (exclusions/blocks)
 
 Authentication:
   auth               Authenticate and manage tokens
@@ -133,6 +135,17 @@ pub enum Commands {
         #[command(subcommand)]
         command: Option<machines::MachinesCommand>,
     },
+    /// Manage indicators (exclusions/blocks)
+    #[command(
+        subcommand_required = false,
+        arg_required_else_help = true,
+        visible_alias = "indicator",
+        hide = true
+    )]
+    Indicators {
+        #[command(subcommand)]
+        command: Option<indicators::IndicatorsCommand>,
+    },
     /// Manage the credential isolation agent
     #[command(subcommand_required = true, arg_required_else_help = true, hide = true)]
     Agent {
@@ -155,6 +168,7 @@ impl Commands {
             Commands::Incidents { .. } => "incidents",
             Commands::Hunting { .. } => "hunting",
             Commands::Machines { .. } => "machines",
+            Commands::Indicators { .. } => "indicators",
             Commands::Agent { .. } => "agent",
             Commands::Completion { .. } => "completion",
         }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -104,4 +104,19 @@ impl MdeClient {
         .await?;
         response::check_response(response).await
     }
+
+    /// Send a DELETE request.
+    pub async fn delete(&self, path: &str) -> Result<reqwest::Response, AppError> {
+        let url = format!("{}{}", self.base_url, path);
+        let token = self.auth.token()?;
+        let response = retry::with_retry(|| async {
+            self.http
+                .delete(&url)
+                .header("Authorization", format!("Bearer {}", token))
+                .send()
+                .await
+        })
+        .await?;
+        response::check_response(response).await
+    }
 }

--- a/src/commands/indicators.rs
+++ b/src/commands/indicators.rs
@@ -1,6 +1,7 @@
 use crate::cli::indicators::IndicatorsCommand;
 use crate::client::MdeClient;
 use crate::error::AppError;
+use crate::models::alert::Severity;
 use crate::models::indicator::{IndicatorAction, IndicatorType};
 use crate::output::OutputFormat;
 
@@ -125,7 +126,9 @@ async fn create(
     }
 
     if let Some(ref severity) = args.severity {
-        body["severity"] = serde_json::json!(severity);
+        let s = Severity::from_str_loose(severity)
+            .ok_or_else(|| AppError::InvalidInput(format!("unknown severity: {}", severity)))?;
+        body["severity"] = serde_json::json!(s.as_str());
     }
 
     if let Some(ref expiration_time) = args.expiration_time {

--- a/src/commands/indicators.rs
+++ b/src/commands/indicators.rs
@@ -1,0 +1,153 @@
+use crate::cli::indicators::IndicatorsCommand;
+use crate::client::MdeClient;
+use crate::error::AppError;
+use crate::models::indicator::{IndicatorAction, IndicatorType};
+use crate::output::OutputFormat;
+
+pub async fn handle(
+    client: &MdeClient,
+    command: &IndicatorsCommand,
+    output_format: OutputFormat,
+    raw: bool,
+) -> Result<(), AppError> {
+    match command {
+        IndicatorsCommand::List(args) => list(client, args, output_format, raw).await,
+        IndicatorsCommand::Create(args) => create(client, args, output_format).await,
+        IndicatorsCommand::Delete(args) => delete(client, args).await,
+    }
+}
+
+async fn list(
+    client: &MdeClient,
+    args: &crate::cli::indicators::ListArgs,
+    output_format: OutputFormat,
+    raw: bool,
+) -> Result<(), AppError> {
+    let mut query: Vec<(String, String)> = Vec::new();
+    query.push(("$top".to_string(), args.top.to_string()));
+
+    let mut filters: Vec<String> = Vec::new();
+
+    if let Some(ref indicator_type) = args.indicator_type {
+        let t = IndicatorType::from_str_loose(indicator_type).ok_or_else(|| {
+            AppError::InvalidInput(format!("unknown indicatorType: {}", indicator_type))
+        })?;
+        filters.push(format!("indicatorType eq '{}'", t.as_str()));
+    }
+
+    if let Some(ref action) = args.action {
+        let a = IndicatorAction::from_str_loose(action)
+            .ok_or_else(|| AppError::InvalidInput(format!("unknown action: {}", action)))?;
+        filters.push(format!("action eq '{}'", a.as_str()));
+    }
+
+    if !filters.is_empty() {
+        query.push(("$filter".to_string(), filters.join(" and ")));
+    }
+
+    let resp: serde_json::Value = client
+        .get_with_query("/api/indicators", &query)
+        .await?
+        .json()
+        .await?;
+
+    match output_format {
+        OutputFormat::Json | OutputFormat::JsonMinify => {
+            crate::output::json::print_json_data(&resp, raw, output_format.is_minify())
+        }
+        OutputFormat::Table => {
+            print_indicators_table(&resp);
+            Ok(())
+        }
+    }
+}
+
+fn print_indicators_table(value: &serde_json::Value) {
+    use crate::output::table::truncate;
+
+    println!(
+        "{:<10} {:<22} {:<14} {:<50} {:<20}",
+        "ID", "TYPE", "ACTION", "VALUE", "TITLE"
+    );
+
+    if let Some(data) = value.get("value").and_then(|d| d.as_array()) {
+        for item in data {
+            let id = item
+                .get("id")
+                .and_then(|i| i.as_u64())
+                .map(|i| i.to_string())
+                .unwrap_or_else(|| "-".to_string());
+            let indicator_type = item
+                .get("indicatorType")
+                .and_then(|t| t.as_str())
+                .unwrap_or("-");
+            let action = item.get("action").and_then(|a| a.as_str()).unwrap_or("-");
+            let value_str = item
+                .get("indicatorValue")
+                .and_then(|v| v.as_str())
+                .unwrap_or("-");
+            let title = item.get("title").and_then(|t| t.as_str()).unwrap_or("-");
+
+            println!(
+                "{:<10} {:<22} {:<14} {:<50} {:<20}",
+                truncate(&id, 10),
+                truncate(indicator_type, 20),
+                truncate(action, 12),
+                truncate(value_str, 48),
+                truncate(title, 18),
+            );
+        }
+    }
+}
+
+async fn create(
+    client: &MdeClient,
+    args: &crate::cli::indicators::CreateArgs,
+    output_format: OutputFormat,
+) -> Result<(), AppError> {
+    let indicator_type = IndicatorType::from_str_loose(&args.indicator_type).ok_or_else(|| {
+        AppError::InvalidInput(format!("unknown indicatorType: {}", args.indicator_type))
+    })?;
+
+    let action = IndicatorAction::from_str_loose(&args.action)
+        .ok_or_else(|| AppError::InvalidInput(format!("unknown action: {}", args.action)))?;
+
+    let mut body = serde_json::json!({
+        "indicatorValue": args.indicator_value,
+        "indicatorType": indicator_type.as_str(),
+        "action": action.as_str(),
+        "title": args.title,
+        "generateAlert": !args.no_alert,
+    });
+
+    if let Some(ref description) = args.description {
+        body["description"] = serde_json::json!(description);
+    }
+
+    if let Some(ref severity) = args.severity {
+        body["severity"] = serde_json::json!(severity);
+    }
+
+    if let Some(ref expiration_time) = args.expiration_time {
+        body["expirationTime"] = serde_json::json!(expiration_time);
+    }
+
+    let resp: serde_json::Value = client.post("/api/indicators", &body).await?.json().await?;
+
+    match output_format {
+        OutputFormat::Json | OutputFormat::JsonMinify => {
+            crate::output::json::print_json_raw(&resp, output_format.is_minify())
+        }
+        OutputFormat::Table => crate::output::json::print_json_raw(&resp, false),
+    }
+}
+
+async fn delete(
+    client: &MdeClient,
+    args: &crate::cli::indicators::DeleteArgs,
+) -> Result<(), AppError> {
+    let path = format!("/api/indicators/{}", args.id);
+    client.delete(&path).await?;
+    println!("Indicator {} deleted.", args.id);
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,4 +2,5 @@ pub mod alerts;
 pub mod auth;
 pub mod hunting;
 pub mod incidents;
+pub mod indicators;
 pub mod machines;

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -119,6 +119,13 @@ where
             )?;
             crate::commands::machines::handle(&client, cmd, output_format, raw).await
         }
+        Commands::Indicators { command: Some(cmd) } => {
+            let client = build_mde_client(
+                mde_base_url,
+                "https://api.securitycenter.microsoft.com/.default",
+            )?;
+            crate::commands::indicators::handle(&client, cmd, output_format, raw).await
+        }
         _ => Ok(()),
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,6 +212,13 @@ async fn run(cli: Cli, credentials: MdeCredentials) -> Result<(), AppError> {
             )?;
             mde::commands::machines::handle(&client, cmd, cli.output, cli.raw).await
         }
+        Commands::Indicators { command: Some(cmd) } => {
+            let client = build_mde_client(
+                &credentials.mde_base_url,
+                "https://api.securitycenter.microsoft.com/.default",
+            )?;
+            mde::commands::indicators::handle(&client, cmd, cli.output, cli.raw).await
+        }
         _ => {
             Cli::command()
                 .find_subcommand(command.name())
@@ -327,6 +334,7 @@ fn requires_agent_routing(command: &Commands) -> bool {
         Commands::Incidents { command } => command.is_some(),
         Commands::Hunting { command } => command.is_some(),
         Commands::Machines { command } => command.is_some(),
+        Commands::Indicators { command } => command.is_some(),
         Commands::Auth { command } => command.is_some(),
         Commands::Agent { .. } => false, // agent commands are handled separately
         Commands::Completion { .. } => false, // handled locally

--- a/src/models/indicator.rs
+++ b/src/models/indicator.rs
@@ -1,0 +1,123 @@
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndicatorType {
+    FileSha256,
+    FileSha1,
+    FileMd5,
+    CertificateThumbprint,
+    IpAddress,
+    DomainName,
+    Url,
+}
+
+impl IndicatorType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::FileSha256 => "FileSha256",
+            Self::FileSha1 => "FileSha1",
+            Self::FileMd5 => "FileMd5",
+            Self::CertificateThumbprint => "CertificateThumbprint",
+            Self::IpAddress => "IpAddress",
+            Self::DomainName => "DomainName",
+            Self::Url => "Url",
+        }
+    }
+
+    pub fn from_str_loose(s: &str) -> Option<Self> {
+        match s.to_lowercase().replace(['-', '_'], "").as_str() {
+            "filesha256" => Some(Self::FileSha256),
+            "filesha1" => Some(Self::FileSha1),
+            "filemd5" => Some(Self::FileMd5),
+            "certificatethumbprint" => Some(Self::CertificateThumbprint),
+            "ipaddress" | "ip" => Some(Self::IpAddress),
+            "domainname" | "domain" => Some(Self::DomainName),
+            "url" => Some(Self::Url),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for IndicatorType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndicatorAction {
+    Allowed,
+    Alert,
+    AlertAndBlock,
+    Block,
+}
+
+impl IndicatorAction {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Allowed => "Allowed",
+            Self::Alert => "Alert",
+            Self::AlertAndBlock => "AlertAndBlock",
+            Self::Block => "Block",
+        }
+    }
+
+    pub fn from_str_loose(s: &str) -> Option<Self> {
+        match s.to_lowercase().replace(['-', '_'], "").as_str() {
+            "allowed" | "allow" => Some(Self::Allowed),
+            "alert" => Some(Self::Alert),
+            "alertandblock" => Some(Self::AlertAndBlock),
+            "block" => Some(Self::Block),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for IndicatorAction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_indicator_type_from_str() {
+        assert_eq!(
+            IndicatorType::from_str_loose("FileSha256"),
+            Some(IndicatorType::FileSha256)
+        );
+        assert_eq!(
+            IndicatorType::from_str_loose("filesha256"),
+            Some(IndicatorType::FileSha256)
+        );
+        assert_eq!(
+            IndicatorType::from_str_loose("ip"),
+            Some(IndicatorType::IpAddress)
+        );
+        assert_eq!(
+            IndicatorType::from_str_loose("domain"),
+            Some(IndicatorType::DomainName)
+        );
+        assert_eq!(IndicatorType::from_str_loose("unknown"), None);
+    }
+
+    #[test]
+    fn test_indicator_action_from_str() {
+        assert_eq!(
+            IndicatorAction::from_str_loose("Allowed"),
+            Some(IndicatorAction::Allowed)
+        );
+        assert_eq!(
+            IndicatorAction::from_str_loose("allow"),
+            Some(IndicatorAction::Allowed)
+        );
+        assert_eq!(
+            IndicatorAction::from_str_loose("AlertAndBlock"),
+            Some(IndicatorAction::AlertAndBlock)
+        );
+        assert_eq!(IndicatorAction::from_str_loose("unknown"), None);
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,2 +1,3 @@
 pub mod alert;
 pub mod incident;
+pub mod indicator;


### PR DESCRIPTION
## What

Add `indicators` subcommand to mde-cli for managing Microsoft Defender for Endpoint Indicators (exclusions/blocks) via the MDE API.

## Why

When a false-positive alert fires (e.g. malware detection in a dev environment), operators need a way to add an exclusion indicator from the CLI without navigating the Defender portal. This change enables that workflow directly from the terminal.

## How

- Added `src/cli/indicators.rs` — CLI argument definitions (`list`, `create`, `delete`)
- Added `src/models/indicator.rs` — `IndicatorType` and `IndicatorAction` enums with loose string parsing
- Added `src/commands/indicators.rs` — command handler calling `/api/indicators` with GET/POST/DELETE
- Added `MdeClient::delete()` method to `src/client/mod.rs`
- Wired routing in `src/cli/mod.rs`, `src/commands/mod.rs`, `src/main.rs`, `src/dispatch.rs`
- `severity` input is validated via existing `models::alert::Severity` enum

## Supported indicatorTypes

`FileSha256`, `FileSha1`, `FileMd5`, `CertificateThumbprint`, `IpAddress`, `DomainName`, `Url`

## Example usage

```bash
# Add a file hash exclusion
mde-cli indicators create <SHA256> \
  --indicator-type FileSha256 \
  --action Allowed \
  --title "Dev env - FP" \
  --no-alert

# List indicators
mde-cli indicators list --indicator-type FileSha256

# Delete an indicator by ID
mde-cli indicators delete 12345
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)