### PR TITLE
ci: verify GitHub Actions are pinned with pinact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,3 +103,25 @@ jobs:
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: zizmor --min-severity medium .
+
+  pinact:
+    name: Pin actions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Install pinact
+        env:
+          PINACT_VERSION: 3.9.0
+          PINACT_SHA256: 3829da718de38b1e914b974c3e77045a256999af84789437a7305b09130d8a6a
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/suzuki-shunsuke/pinact/releases/download/v${PINACT_VERSION}/pinact_linux_amd64.tar.gz" -o pinact.tar.gz
+          echo "${PINACT_SHA256}  pinact.tar.gz" | sha256sum -c -
+          tar xf pinact.tar.gz pinact
+          sudo mv pinact /usr/local/bin/pinact
+      - name: Verify actions are pinned
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pinact run --verify --check

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,3 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3


### PR DESCRIPTION
## Summary

- CI に `pinact` ジョブを追加して、`pinact run --verify --check` で全 workflow のアクションが SHA で固定されていることを検証します。
- 既存の手動 SHA 固定を機械的に担保し、退行や mutable tag 改ざんへの耐性を強化します。

## Why

サプライチェーン攻撃では、アクションの可変タグ（mutable tag）が書き換えられて広範な被害が発生するパターンが観測されています。代表例は tj-actions/changed-files の侵害（CVE-2025-30066）で、23,000 以上のリポジトリが影響を受けました。本 PR は OpenSSF Scorecard の Pinned-Dependencies 指標・SLSA の build integrity 要件に沿った対策です。

## Implementation notes

- `.pinact.yaml` を追加（pinact v3 のデフォルト設定）。
- `pinact` バイナリは公式 Release からバージョン + SHA-256 固定で取得します（`curl | bash` パターンを避け、`sha256sum -c` で検証）。
- 検証のみで自動 commit や PR は行いません (`--verify --check`)。

## References

- [CVE-2025-30066: tj-actions/changed-files supply chain compromise](https://nvd.nist.gov/vuln/detail/CVE-2025-30066)
- [pinact](https://github.com/suzuki-shunsuke/pinact)
- [OpenSSF Scorecard - Pinned-Dependencies](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)

## Test plan

- [ ] Pin actions ジョブが CI で成功する
- [ ] 意図的にタグ参照へ戻した PR ではジョブが失敗する（動作確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)