### PR TITLE
ci: harden workflows and add zizmor static analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
         with:
           toolchain: stable
@@ -26,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
         with:
           toolchain: stable
@@ -38,6 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
         with:
           toolchain: stable
@@ -52,6 +58,8 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
         with:
           toolchain: stable
@@ -63,6 +71,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: taiki-e/install-action@eea29cff9a2b68892c0845ae3e4f45fc47ee9354 # v2.75.13
         with:
           tool: cargo-audit@0.22.1
@@ -73,7 +83,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
+
+  zizmor:
+    name: Analyze workflows
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: taiki-e/install-action@eea29cff9a2b68892c0845ae3e4f45fc47ee9354 # v2.75.13
+        with:
+          tool: zizmor@1.24.0
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: zizmor --min-severity medium .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
             artifact: mde-cli
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
         with:
@@ -41,10 +43,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
-
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          key: ${{ matrix.target }}
 
       - name: Build
         run: cargo build --release --locked --target ${{ matrix.target }}
@@ -67,6 +65,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -76,4 +76,5 @@ jobs:
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "${{ github.ref_name }}" artifacts/*.tar.gz --generate-notes
+          REF_NAME: ${{ github.ref_name }}
+        run: gh release create "$REF_NAME" artifacts/*.tar.gz --generate-notes


### PR DESCRIPTION
## Summary

- zizmor を CI に追加し、ワークフローの security findings を機械的に検出します。
- 同時に zizmor が検出した既存の findings をすべて修正します（persist-credentials、template-injection、cache-poisoning）。

## Why

actionlint は構文とシェルチェックが中心で、CI/CD サプライチェーン攻撃で悪用される以下の反パターンは検出しません。本 PR で zizmor を導入し、ゲートとして機能させます。

- **template-injection**: `\${{ github.* }}` をシェル内で直接展開するとコード注入の経路になります（tj-actions/changed-files 侵害で実際に使われた手口）。
- **artipacked (persist-credentials)**: `actions/checkout` はデフォルトで GITHUB_TOKEN をローカル `.git/config` に残します。後続の任意ステップがトークンを読み出せる状態になります。
- **cache-poisoning**: リリースビルドで永続キャッシュを使うと、過去に汚染されたキャッシュが配布バイナリに影響します。

## Changes

### zizmor 導入
- `taiki-e/install-action` で pinned version をインストール（既存の cargo-audit と同じ方式）
- `zizmor --min-severity medium .` を CI で実行

### 既存 findings の修正
- `persist-credentials: false` を全 `actions/checkout` に付与（ci.yml × 6、release.yml × 2）。
- release.yml の `gh release create` を `env: REF_NAME` 経由に変更し、shell 内の直接展開を排除。
- release.yml から `Swatinem/rust-cache` を削除。リリースビルドはキャッシュを使わずクリーンに実行。

## References

- [zizmor audits](https://docs.zizmor.sh/audits/)
- [template-injection](https://docs.zizmor.sh/audits/#template-injection)
- [artipacked (persist-credentials)](https://docs.zizmor.sh/audits/#artipacked)
- [cache-poisoning](https://docs.zizmor.sh/audits/#cache-poisoning)
- [CVE-2025-30066: tj-actions/changed-files supply chain compromise](https://nvd.nist.gov/vuln/detail/CVE-2025-30066)

## Test plan

- [ ] `Analyze workflows` ジョブが CI で成功する
- [ ] タグ push で release workflow が成功する（cache 削除後も build が通る）

🤖 Generated with [Claude Code](https://claude.com/claude-code)