### PR TITLE
chore(codeowners): require review on security-sensitive paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,20 @@
-* @hiboma
+# Default owner for every file in the repository.
+*                          @hiboma
+
+# Security-sensitive paths. Duplicated as explicit rules so that any
+# future co-maintainer still needs the named owner's review on these.
+
+# GitHub Actions workflows and dependency automation.
+/.github/                  @hiboma
+/.github/workflows/        @hiboma
+/.github/dependabot.yml    @hiboma
+/.pinact.yaml              @hiboma
+
+# Rust dependency manifest and lockfile.
+/Cargo.toml                @hiboma
+/Cargo.lock                @hiboma
+
+# Authentication (OAuth2, device flow, browser login) and the
+# credential isolation agent that brokers access tokens.
+/src/auth/                 @hiboma
+/src/agent/                @hiboma


### PR DESCRIPTION
## Summary

- `CODEOWNERS` をセキュリティ重要パス単位に細分化します。
- 現状は単独 maintainer のため即時の振る舞いは変わりませんが、将来 co-maintainer を迎えた際に supply chain / 認証 / agent のレビュー責務が維持されます。

## Why

サプライチェーン攻撃の典型的なエントリーポイント（ワークフロー定義・依存マニフェスト・認証フロー）は、プロジェクトの他の箇所と同じ粒度で扱うべきではありません。CODEOWNERS を細分化しておくと、Branch Protection の require_code_owner_review と組み合わせて、該当パスへの変更時に必ず名指しのオーナーのレビューが必要になります。

本 PR は単独 maintainer の段階での準備であり、co-maintainer が参加した時点で load-bearing になります。

## Covered paths

- `/.github/`、`/.github/workflows/`、`/.github/dependabot.yml`、`/.pinact.yaml`
- `/Cargo.toml`、`/Cargo.lock`
- `/src/auth/`、`/src/agent/`

## Test plan

- [ ] merge 後、対象パスの変更 PR が `@hiboma` に自動アサインされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)