### PR TITLE
feat(credentials): back client_secret with macOS Keychain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +415,7 @@ dependencies = [
  "dirs",
  "dotenvy",
  "gag",
+ "keyring",
  "libc",
  "libproc",
  "mockito",
@@ -1094,6 +1115,18 @@ checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -1803,6 +1836,42 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 libproc = "0.14"
+keyring = { version = "3", default-features = false, features = ["apple-native"] }
 
 [profile.release]
 opt-level = "z"

--- a/README.md
+++ b/README.md
@@ -52,6 +52,92 @@ client_id = "your-client-id"
 client_secret = "your-client-secret"
 ```
 
+`client_secret` should preferably be stored in the OS credential store
+instead — see [Credential storage](#credential-storage) below.
+
+### Credential storage
+
+`mde-cli` resolves the OAuth2 `client_secret` from the following sources,
+highest priority first:
+
+1. `MDE_CLIENT_SECRET` environment variable
+2. **macOS Keychain** (login keychain, `service=dev.mde-cli`,
+   `account=client_secret`)
+3. `~/.config/mde/credentials.toml`
+
+Storing the secret in the Keychain keeps it out of plaintext config
+files (and out of dotfile backups, Time Machine snapshots, accidental
+git commits, etc.).
+
+#### Storing the secret
+
+```bash
+# Interactive prompt (recommended)
+mde-cli credentials set client-secret
+
+# Non-interactive (CI / scripts)
+echo "$MDE_CLIENT_SECRET" | mde-cli credentials set client-secret --stdin
+
+# Confirm presence (the value is never printed)
+mde-cli credentials status
+```
+
+To migrate an existing plaintext `client_secret` from `credentials.toml`
+into the Keychain in one step:
+
+```bash
+mde-cli credentials migrate
+```
+
+`migrate` writes a 0o600 backup, performs an atomic rewrite of the toml
+(blanking `client_secret`), and rolls back the Keychain entry if the
+rewrite fails. The backup still contains the plaintext secret — delete
+it once you have verified the new path works.
+
+#### Inspecting the entry
+
+The entry lives in your **login** keychain as a `generic password`:
+
+| Attribute | Value |
+|---|---|
+| Kind | `application password` |
+| Service (Name / Where) | `dev.mde-cli` |
+| Account | `client_secret` |
+
+GUI:
+
+```
+Keychain Access.app → login → Passwords → search "dev.mde-cli"
+```
+
+CLI (metadata only):
+
+```bash
+security find-generic-password -s dev.mde-cli -a client_secret
+```
+
+#### Removing the entry
+
+```bash
+mde-cli credentials delete client-secret
+# or via macOS:
+security delete-generic-password -s dev.mde-cli -a client_secret
+```
+
+#### Notes on Keychain prompts
+
+macOS shows an access-prompt dialog the first time `mde-cli` reads the
+Keychain entry. Choosing **Always Allow** suppresses subsequent
+prompts.
+
+The dialog reappears whenever the binary's code signature changes —
+including after every `cargo install` rebuild. This is a macOS ACL
+behavior, not an `mde-cli` bug.
+
+If a non-`mde-cli` build of the binary keeps causing prompts, you can
+inspect the entry's Access Control list in Keychain Access.app and
+remove or replace the allowed-applications list.
+
 ### Azure AD App Registration
 
 1. Register an application in [Azure AD](https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade)

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,70 @@
+# TODO
+
+## Follow-ups from PR #52 (Keychain credentials)
+
+The Keychain credentials PR shipped the core trait + subcommand + migrate
+flow, but reviewers surfaced several improvements that are out of scope
+for that PR. They are tracked here so they do not get lost.
+
+### Security
+
+- [ ] **Drop `MDE_*` keys loaded from `.env`** before resolution
+      (`src/main.rs:16` `dotenvy::dotenv()`). A malicious `.env` in cwd
+      can override the user's Keychain secret with attacker-controlled
+      credentials, redirecting OAuth flows to the attacker's tenant.
+      Either gate dotenv behind an explicit flag, or scrub `MDE_*` keys
+      that came from `.env` after loading. Reviewer flagged as High.
+
+- [ ] **Use `tempfile::NamedTempFile::new_in`** for the atomic_replace
+      tempfile instead of a unix-nanos suffix
+      (`src/commands/credentials.rs` `atomic_replace`). The current name
+      is predictable; `create_new` + `O_EXCL` already blocks the symlink
+      attack but switching to `tempfile` removes a class of bugs and
+      cleans up better on drop. Reviewer flagged as Medium.
+
+- [ ] **Zeroize secret-bearing strings on drop** in the `credentials`
+      subcommand path (`src/commands/credentials.rs`). The plaintext
+      sits in unzeroed `String`s through `set_value` / `migrate`.
+      Reviewer flagged as Low. Likely needs `secrecy::Secret<String>`
+      and a sweep of where the secret is held.
+
+- [ ] **Scrub `MDE_*` env vars in direct-API mode**, not just agent
+      mode (`src/main.rs` direct path vs `clear_env` in agent path).
+      For long-running invocations the secret is visible via
+      `ps -E` / `/proc/<pid>/environ` until process exit. Reviewer
+      flagged as Low.
+
+### Compatibility
+
+- [ ] **Locale-translated Keychain errors** in `classify_keyring_err`
+      (`src/config/credential_store.rs`). The string-match allowlist
+      ("no default keychain" etc.) misses Japanese / other locales of
+      the same `errSecNoDefaultKeychain` error, causing those users to
+      hit the no-toml-fallback branch on a clean machine. Either match
+      on `keyring::Error` variants (if exposed) or read the underlying
+      OSStatus directly.
+
+- [ ] **Document mid-migration Ctrl-C recovery** in the README. The
+      migrate flow is atomic at the tempfile-rename step but Ctrl-C
+      between Keychain write and the rewrite leaves both copies present
+      (Keychain entry + plaintext toml). Recoverable but not documented.
+
+### DX
+
+- [ ] **Replace emoji** in `set_value` / `delete_value` output with
+      plain text to match the rest of the CLI (and the project's
+      no-emoji convention in CLAUDE.md). The migrate output already
+      avoids them.
+
+- [ ] **Document the credentials.toml search order** in the README.
+      The cwd-relative `.mde-credentials.toml` having higher priority
+      than `~/.config/mde/credentials.toml` can surprise migrate users.
+
+- [ ] **Improve Keychain ACL error guidance**. When `status` shows
+      `error (UNIX[Operation not permitted])`, the user should be
+      pointed at the README section explaining how to re-grant access
+      via Keychain Access.app's Access Control tab.
+
+- [ ] **Stronger backup-warning callout in README** ("Credential
+      storage" section). The migrate warning in the CLI output is
+      multi-line warning but the README mention is only one paragraph.

--- a/docs/adr/0004-keychain-backed-client-secret.md
+++ b/docs/adr/0004-keychain-backed-client-secret.md
@@ -1,0 +1,255 @@
+# ADR-0004: Keychain による client_secret の保管
+
+## ステータス
+
+採択（実装済み、PR #52）
+
+## 日付
+
+2026-04-21
+
+## コンテキスト
+
+`mde-cli` の OAuth2 client_secret は、これまで `~/.config/mde/credentials.toml`
+に平文で保存されていました。`MDE_CLIENT_SECRET` 環境変数からも読み込めますが、
+永続的な保管手段は事実上 toml ファイルのみでした。
+
+### 脅威
+
+平文ファイル保管には以下のリスクがあります。
+
+1. **バックアップ経由の漏洩**: Time Machine、iCloud Drive、`tar -czf`
+   など、ホームディレクトリ単位のバックアップに client_secret が
+   そのまま含まれます。バックアップは複製・配布されやすく、いったん
+   流出すると回収不可能です。
+2. **同一ユーザー権限のプロセスからの読み取り**: ファイルパーミッション
+   `0600` のみが防御層です。同じ uid で動く任意のマルウェア・スクリプト
+   が無条件に読めます。macOS Keychain は ACL で「特定の署名済みアプリの
+   み」に制限できます。
+3. **dotfiles リポジトリへの誤コミット**: `.gitignore` の漏れや
+   `git add -A` 経由で公開リポジトリに push される事故が起こりえます。
+4. **AI エージェントによるコンテキスト汚染**: Claude Code 等の LLM
+   エージェントが「設定確認のため」と称して `cat credentials.toml` を
+   実行し、出力が会話履歴・PR 説明・サポートログに残るリスクが
+   あります。
+
+### 制約
+
+- macOS 環境を主要ターゲットとします。Linux / Windows サポートは
+  trait 設計で将来追加可能とします。
+- 既存の toml 利用者がアップグレードしただけで挙動が変わらないこと
+  （後方互換）。
+- agent モード（ADR-0001）との整合性を保つこと。agent は親プロセスで
+  解決した credentials を子プロセスのメモリに渡すため、Keychain への
+  追加読み込みが per-request で発生してはなりません。
+- CI / sandbox 環境（default keychain が無い）で resolve が破綻しない
+  こと。
+
+## 決定
+
+### CredentialStore trait による抽象化
+
+`src/config/credential_store.rs` に `CredentialStore` trait を定義し、
+プラットフォーム固有の保管バックエンドを抽象化します。
+
+```rust
+pub trait CredentialStore {
+    fn get(&self, key: &str) -> Result<Option<String>, StoreError>;
+    fn set(&self, key: &str, value: &str) -> Result<(), StoreError>;
+    fn delete(&self, key: &str) -> Result<(), StoreError>;
+}
+```
+
+実装は 3 種類です。
+
+| 実装 | 用途 | 配置 |
+|---|---|---|
+| `KeychainStore` | macOS Keychain（本番） | `#[cfg(target_os = "macos")]` |
+| `MemoryStore` | テスト用 in-memory | `#[cfg(test)]` |
+| なし | 非 macOS ターゲット | `default_store()` が `None` を返す |
+
+`KeychainStore` は `keyring` crate（`apple-native` feature）経由で
+`Security.framework` の `SecItemAdd` / `SecItemCopyMatching` を
+呼び出します。
+
+### Keychain エントリの属性
+
+| 属性 | 値 |
+|---|---|
+| Kind | `application password`（`kSecClassGenericPassword`） |
+| Service | `dev.mde-cli` |
+| Account | `client_secret` |
+| Keychain | login（デフォルト） |
+
+Service 名は bundle identifier 風の固定文字列です。Account 名は
+`KEY_CLIENT_SECRET` 定数として `src/config/credential_store.rs` で
+公開しています。
+
+### Resolve の優先順位
+
+`MdeCredentials::resolve()` は client_secret を以下の順で解決します。
+
+```
+MDE_CLIENT_SECRET (env) > Keychain > credentials.toml > None
+```
+
+tenant_id / client_id は機密性が低いため Keychain に格納せず、CLI args >
+env > toml の従来順を維持します。
+
+### StoreError の分類とフォールバック判断
+
+`StoreError` を 2 variant に分けます。
+
+| Variant | 意味 | resolve の挙動 |
+|---|---|---|
+| `Unavailable(msg)` | 保管バックエンドそのものが存在しない（非 macOS、CI sandbox の default keychain なし） | 静かに toml にフォールバック |
+| `Backend(msg)` | バックエンドへのアクセスに失敗（ユーザーが prompt を Deny、Keychain daemon ダウン、ACL 不整合） | **toml にフォールバックしない**。stderr に強い警告を出して `None` を返す |
+
+`Backend` 時に toml フォールバックを許可すると、Keychain に移行済みの
+ユーザーが Deny した瞬間に古い toml の secret が黙って採用されます。
+これは Keychain への移行という決定そのものを台無しにするため、
+明示的な失敗を選びます。
+
+`KeychainStore` は `keyring::Error` を `classify_keyring_err` で振り分け、
+"no default keychain" 系のメッセージのみを `Unavailable` に分類します。
+
+### `mde-cli credentials` サブコマンド
+
+ユーザーが Keychain エントリを操作するためのサブコマンドを追加します。
+
+| サブコマンド | 機能 |
+|---|---|
+| `set <field> [--stdin]` | 対話的または stdin 経由で保管 |
+| `delete <field>` | 削除 |
+| `status` | 各エントリの「stored / not stored」のみを表示（値は出さない） |
+| `migrate [--dry-run]` | credentials.toml の client_secret を Keychain に移し、toml から削除 |
+
+`get` サブコマンドは**意図的に提供しません**。理由は以下です。
+
+- 値を取り出す正当なユースケースが存在しません。動作確認は `status`
+  で十分です。バックアップは Azure portal で client_secret を再発行
+  するのが正攻法です。
+- AI エージェントが「デバッグのため」と称して `get` を実行し、出力が
+  会話履歴・ログ・PR 説明に流出する事故を構造的に防ぎます。
+- シェル履歴・端末スクロールバックへの汚染を防ぎます。
+
+### Migrate の安全策
+
+`migrate` は以下の順で実行します。
+
+1. credentials.toml から client_secret を抽出（quoted basic string のみ
+   サポート、literal / multi-line は明示エラー）
+2. ユーザーに移行確認（default No）
+3. **Keychain への書き込み**（toml 未変更のため失敗時の rollback 不要）
+4. ユーザーに plaintext 処分方法を確認:
+   - **default Yes**: tempfile + atomic rename で `client_secret` 行を
+     完全削除。disk 上に plaintext は残らない
+   - **No**: 0o600 backup を作成 + toml は新形式に書き換え + 多段の
+     警告を表示
+5. 失敗時は Keychain エントリを rollback し、plaintext がどこに残って
+   いるかを明示
+
+backup 作成を default にせず default 削除にしたのは、レビュー指摘に
+よる方針変更です。backup を残す選択は意識的にしか取れず、取った場合
+は強い警告を出します。
+
+### Debug マスク
+
+`MdeCredentials` の `Debug` 実装を手動化し、`client_secret` と
+`access_token` を `***` でマスクします。`dbg!` / `{:?}` 経由の
+偶発的な leak を防ぎます。
+
+### ローカル平文の取り扱い
+
+migrate で作成する backup ファイルは `OpenOptions::mode(0o600) +
+create_new(true)` で書き出します。`fs::copy` は元ファイルの mode を
+継承する（典型的には `0o644`）ため使いません。toml 本体の書き換えは
+sibling tempfile への書き込み + `rename(2)` でアトミックに行います。
+
+## 結果
+
+### Positive
+
+- client_secret がホームディレクトリのバックアップ・他プロセス・
+  dotfiles リポジトリから完全に隔離されます
+- macOS 標準の Keychain Access.app から GUI で監査・削除可能です
+- trait 抽象化により Linux / Windows backend の追加コストが小さい
+  です
+- 既存 toml ユーザーは何もせずアップグレードしても挙動が変わらず、
+  `migrate` で能動的に移行できます
+
+### Negative
+
+- 初回アクセスと `cargo install` 再ビルドのたびに Keychain ACL
+  ダイアログが出ます。これは macOS の codesign ベース ACL に由来する
+  挙動で、Homebrew bottle のような署名安定なバイナリ配布で緩和でき
+  ます
+- `keyring` crate の追加でサプライチェーン面積が増えます。`cargo
+  audit` での監視を継続します
+- 環境変数優先のため、`.env` 経由の `MDE_CLIENT_SECRET` 上書き攻撃は
+  Keychain で防御できません（TODO.md に follow-up として記録）
+
+## 代替案
+
+### A. `security` コマンドのサブプロセス呼び出し
+
+`/usr/bin/security add-generic-password` を `Command` で叩く方式です。
+追加 crate は不要ですが、子プロセス起動コスト・シェルエスケープ・
+ACL の細かい制御が課題です。`keyring` crate は `Security.framework` を
+直接 FFI で呼ぶため、子プロセス不要・型安全です。
+
+### B. `security-framework` crate を直接利用
+
+最低レベルです。ACL を細かく制御できますが、コード量が増え、Linux /
+Windows backend を将来追加する際に再抽象化が必要です。`keyring` crate
+は最初から cross-platform 抽象化を持っています。
+
+### C. tenant_id / client_id も Keychain に格納
+
+これらは機密性が低く（公開可能な識別子）、Keychain に入れると ACL
+ダイアログ頻度が増えるだけで便益が小さいため不採用としました。
+toml に残します。
+
+### D. backup を default で作成し続ける（PR 初版の挙動）
+
+レビューで指摘されたとおり、backup ファイル自体が plaintext を持つ
+ため移行の意図を裏切ります。「default は完全削除、backup は opt-in」
+に変更しました。
+
+## 先行事例
+
+- **ssh-agent / gpg-agent**: 秘密鍵をプロセスメモリに保持する方式
+  （ADR-0001 で採用済）
+- **`gh` CLI**: Keychain / Secret Service / Credential Manager を抽象化
+  して OAuth トークンを保管
+- **Docker CLI**: `docker-credential-osxkeychain` 等の credential
+  helper を介して registry credentials を Keychain に保管
+
+## 影響範囲
+
+- `Cargo.toml` — `keyring` crate を `target.cfg(target_os = "macos")` で
+  追加
+- `src/config/credential_store.rs` — trait と KeychainStore 実装
+- `src/config/mod.rs` — `MdeCredentials::resolve()` の優先順位拡張、
+  `Debug` の手動マスク化
+- `src/cli/credentials.rs` — clap サブコマンド定義
+- `src/commands/credentials.rs` — handler 実装
+- `src/main.rs` — `credentials` / `completion` サブコマンドで
+  resolve をスキップ
+- `README.md` — Credential storage セクション追加
+
+## セキュリティ考慮事項
+
+- **codesign の安定性**: `cargo install` で再ビルドするたびに ACL が
+  再評価され、ダイアログが再出します。本質的な解決には Homebrew bottle
+  のような署名済みバイナリ配布が必要です
+- **`MDE_CLIENT_SECRET` 環境変数の優先**: 攻撃者が cwd に malicious
+  `.env` を置けば Keychain 値を上書き可能です。TODO.md に follow-up
+  として記録、別 PR で対処予定
+- **Keychain メモリダンプ**: root 権限による Keychain unlock 後の
+  メモリスキャンは ADR-0003 のプロセス hardening の延長で緩和し、
+  本 ADR のスコープ外とします
+- **`keyring::Error` の locale 翻訳**: 日本語 macOS で `errSecNoDefault
+  Keychain` のメッセージが翻訳されると `classify_keyring_err` の
+  string match 漏れにより `Backend` 扱いになり、toml フォールバックが
+  失われます。TODO.md に follow-up として記録

--- a/src/cli/credentials.rs
+++ b/src/cli/credentials.rs
@@ -35,9 +35,12 @@ pub enum CredentialField {
 }
 
 impl CredentialField {
-    pub fn account(self) -> &'static str {
+    /// The logical key under which this field is stored in the credential
+    /// store. Returns a static identifier (e.g. "client_secret") — never
+    /// the credential value.
+    pub fn key(self) -> &'static str {
         match self {
-            CredentialField::ClientSecret => crate::config::credential_store::ACCOUNT_CLIENT_SECRET,
+            CredentialField::ClientSecret => crate::config::credential_store::KEY_CLIENT_SECRET,
         }
     }
 }

--- a/src/cli/credentials.rs
+++ b/src/cli/credentials.rs
@@ -1,0 +1,43 @@
+use clap::{Subcommand, ValueEnum};
+
+#[derive(Subcommand)]
+pub enum CredentialsCommand {
+    /// Store a credential in the OS credential store (e.g. macOS Keychain).
+    #[command(arg_required_else_help = true)]
+    Set {
+        #[arg(value_enum)]
+        field: CredentialField,
+        /// Read the value from stdin instead of prompting interactively.
+        /// Useful for CI / automation. The value must be a single line.
+        #[arg(long)]
+        stdin: bool,
+    },
+    /// Delete a credential from the OS credential store.
+    #[command(arg_required_else_help = true)]
+    Delete {
+        #[arg(value_enum)]
+        field: CredentialField,
+    },
+    /// Show whether each credential is stored. Values are never printed.
+    Status,
+    /// Migrate `client_secret` from credentials.toml into the OS credential store.
+    Migrate {
+        /// Show what would be done without modifying anything.
+        #[arg(long)]
+        dry_run: bool,
+    },
+}
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub enum CredentialField {
+    /// OAuth2 client secret. Sensitive — stored only in the credential store.
+    ClientSecret,
+}
+
+impl CredentialField {
+    pub fn account(self) -> &'static str {
+        match self {
+            CredentialField::ClientSecret => crate::config::credential_store::ACCOUNT_CLIENT_SECRET,
+        }
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -142,7 +142,19 @@ pub enum Commands {
         command: agent::AgentCommand,
     },
     /// Manage stored credentials (macOS Keychain)
-    #[command(subcommand_required = true, arg_required_else_help = true, hide = true)]
+    #[command(
+        subcommand_required = true,
+        arg_required_else_help = true,
+        hide = true,
+        long_about = "Manage stored credentials (macOS Keychain).\n\
+                      \n\
+                      Secrets are stored in the login keychain under \
+                      service=\"dev.mde-cli\". Inspect or delete via \
+                      Keychain Access.app or `security \
+                      find-generic-password -s dev.mde-cli`. See README \
+                      for the full credential resolution order and \
+                      migration steps."
+    )]
     Credentials {
         #[command(subcommand)]
         command: credentials::CredentialsCommand,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,7 @@
 pub mod agent;
 pub mod alerts;
 pub mod auth;
+pub mod credentials;
 pub mod hunting;
 pub mod incidents;
 pub mod machines;
@@ -31,6 +32,7 @@ Resources:
 Authentication:
   auth               Authenticate and manage tokens
   agent              Manage the credential isolation agent
+  credentials        Manage stored credentials (Keychain on macOS)
 
 Other:
   completion         Generate shell completion script
@@ -139,6 +141,12 @@ pub enum Commands {
         #[command(subcommand)]
         command: agent::AgentCommand,
     },
+    /// Manage stored credentials (macOS Keychain)
+    #[command(subcommand_required = true, arg_required_else_help = true, hide = true)]
+    Credentials {
+        #[command(subcommand)]
+        command: credentials::CredentialsCommand,
+    },
     /// Generate shell completion script
     #[command(hide = true)]
     Completion {
@@ -156,6 +164,7 @@ impl Commands {
             Commands::Hunting { .. } => "hunting",
             Commands::Machines { .. } => "machines",
             Commands::Agent { .. } => "agent",
+            Commands::Credentials { .. } => "credentials",
             Commands::Completion { .. } => "completion",
         }
     }

--- a/src/commands/credentials.rs
+++ b/src/commands/credentials.rs
@@ -85,8 +85,14 @@ fn print_status(store: &dyn CredentialStore) -> Result<(), AppError> {
 }
 
 fn migrate(store: &dyn CredentialStore, dry_run: bool) -> Result<(), AppError> {
-    let path = find_credentials_toml()
-        .ok_or_else(|| AppError::Config("no credentials.toml found to migrate from".to_string()))?;
+    let path = find_credentials_toml().ok_or_else(|| {
+        AppError::Config(
+            "no credentials.toml found to migrate from. \
+             To store a secret directly in the Keychain, run: \
+             mde-cli credentials set client-secret"
+                .to_string(),
+        )
+    })?;
     // Resolve to canonical path so the user sees what we will actually
     // mutate, not a relative path that could be interpreted as something
     // surprising (e.g. `.mde-credentials.toml` in cwd).
@@ -100,6 +106,11 @@ fn migrate(store: &dyn CredentialStore, dry_run: bool) -> Result<(), AppError> {
         SecretScan::Present(s) => s,
         SecretScan::Absent => {
             println!("  client_secret: not present (nothing to migrate)");
+            println!();
+            println!(
+                "If you want to store a secret in the Keychain anyway, run: \
+                 mde-cli credentials set client-secret"
+            );
             return Ok(());
         }
         SecretScan::Unsupported(form) => {
@@ -117,12 +128,91 @@ fn migrate(store: &dyn CredentialStore, dry_run: bool) -> Result<(), AppError> {
         return Ok(());
     }
 
-    // Confirm before mutating. Echo the canonical path again so a hostile
-    // cwd cannot smuggle in a different file between the find and the prompt.
-    print!(
-        "Migrate client_secret from {} to the credential store? [y/N]: ",
-        canonical.display()
-    );
+    // Step 1: confirm the migration itself. Echo the canonical path again
+    // so a hostile cwd cannot smuggle in a different file between the find
+    // and the prompt.
+    if !prompt_yes_no(
+        &format!(
+            "Migrate client_secret from {} to the credential store?",
+            canonical.display()
+        ),
+        false,
+    )? {
+        println!("Aborted.");
+        return Ok(());
+    }
+
+    // Step 2: write to the credential store first. We have not touched the
+    // toml yet, so any failure here leaves the user in their pre-migration
+    // state with no rollback needed.
+    store
+        .set(KEY_CLIENT_SECRET, &secret)
+        .map_err(|e| AppError::Config(format!("credential store: {}", e)))?;
+    println!("Stored client_secret in credential store");
+
+    // Step 3: ask how to dispose of the plaintext copy. The default is the
+    // safest option — fully remove it. Keeping a backup leaves a 0o600
+    // copy on disk that the user has to remember to delete; we surface
+    // that risk loudly when they choose to keep it.
+    let mode = prompt_disposal()?;
+    let updated = remove_client_secret_line(&original);
+
+    match mode {
+        DisposalMode::Remove => {
+            if let Err(e) = atomic_replace(&path, updated.as_bytes()) {
+                rollback_and_fail(store, &canonical, &e.to_string(), None)?;
+            }
+            println!("Removed client_secret line from {}", canonical.display());
+            println!();
+            println!("Done. The plaintext secret no longer exists on disk.");
+        }
+        DisposalMode::KeepBackup => {
+            // Create the backup BEFORE rewriting the original, so a failure
+            // partway through still leaves something recoverable. 0o600 +
+            // create_new ensures the backup is private and never clobbers
+            // an older one.
+            let backup = backup_path(&path);
+            if let Err(e) = write_secret_file(&backup, original.as_bytes(), true) {
+                rollback_and_fail(store, &canonical, &format!("{}", e), None)?;
+            }
+            if let Err(e) = atomic_replace(&path, updated.as_bytes()) {
+                // Try to remove the backup we just wrote, then roll back
+                // Keychain. The original toml is untouched.
+                let _ = fs::remove_file(&backup);
+                rollback_and_fail(store, &canonical, &e.to_string(), None)?;
+            }
+            println!(
+                "Removed client_secret line from {} (backup at {})",
+                canonical.display(),
+                backup.display()
+            );
+            println!();
+            println!(
+                "⚠️  WARNING: {} still contains the plaintext client_secret.",
+                backup.display()
+            );
+            println!("⚠️  This file defeats the purpose of moving the secret to the Keychain.");
+            println!("⚠️  Delete it as soon as you have confirmed the new setup works:");
+            println!("       rm {}", backup.display());
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum DisposalMode {
+    /// Remove the `client_secret` line outright; no plaintext copy remains.
+    Remove,
+    /// Keep a 0o600 backup of the original toml alongside the rewritten file.
+    KeepBackup,
+}
+
+/// Ask the user a yes/no question and return the parsed answer.
+/// `default_yes` controls what an empty (just-Enter) response means.
+fn prompt_yes_no(question: &str, default_yes: bool) -> Result<bool, AppError> {
+    let suffix = if default_yes { "[Y/n]" } else { "[y/N]" };
+    print!("{} {}: ", question, suffix);
     io::stdout()
         .flush()
         .map_err(|e| AppError::Config(format!("flush stdout: {}", e)))?;
@@ -130,58 +220,58 @@ fn migrate(store: &dyn CredentialStore, dry_run: bool) -> Result<(), AppError> {
     io::stdin()
         .read_line(&mut answer)
         .map_err(|e| AppError::Config(format!("read stdin: {}", e)))?;
-    if !matches!(answer.trim(), "y" | "Y" | "yes") {
-        println!("Aborted.");
-        return Ok(());
+    Ok(match answer.trim() {
+        "" => default_yes,
+        s => matches!(s, "y" | "Y" | "yes" | "Yes" | "YES"),
+    })
+}
+
+/// Ask the user how to dispose of the plaintext copy of `client_secret`
+/// after a successful Keychain write. Default is `Remove` — the safest
+/// option, since any copy left on disk re-introduces the risk we just
+/// migrated away from.
+fn prompt_disposal() -> Result<DisposalMode, AppError> {
+    if prompt_yes_no(
+        "Remove the plaintext client_secret line from credentials.toml? \
+         (Recommended. Choosing 'no' keeps a 0600 backup of the original on disk.)",
+        true,
+    )? {
+        Ok(DisposalMode::Remove)
+    } else {
+        Ok(DisposalMode::KeepBackup)
     }
+}
 
-    // Backup with restrictive permissions (0o600). `fs::copy` would inherit
-    // the source mode, which is commonly 0o644 — leaving the plaintext
-    // backup world-readable. Use create_new + 0o600 + manual byte copy.
-    let backup = backup_path(&path);
-    write_secret_file(&backup, original.as_bytes(), true)?;
-    println!("Backup written (mode 0600): {}", backup.display());
-
-    store
-        .set(KEY_CLIENT_SECRET, &secret)
-        .map_err(|e| AppError::Config(format!("credential store: {}", e)))?;
-    println!("Stored client_secret in credential store");
-
-    // Atomic rewrite: write to a sibling tempfile then rename(). If anything
-    // fails, the original file is untouched and we roll back the Keychain
-    // write so the user is not left in an inconsistent half-migrated state.
-    let updated = blank_client_secret(&original);
-    if let Err(e) = atomic_replace(&path, updated.as_bytes()) {
-        // Roll back the Keychain entry we just wrote, then surface a
-        // detailed error so the user knows where the secret lives now.
-        let rb = store.delete(KEY_CLIENT_SECRET);
-        let rb_msg = match rb {
-            Ok(()) => "credential store entry rolled back".to_string(),
-            Err(re) => format!(
-                "WARNING: failed to roll back credential store entry: {}",
-                re
-            ),
-        };
-        return Err(AppError::Config(format!(
-            "failed to update {}: {}. {}. The plaintext secret is still in {} and {}.",
-            canonical.display(),
-            e,
-            rb_msg,
-            canonical.display(),
-            backup.display(),
-        )));
-    }
-    println!("Cleared client_secret in {}", canonical.display());
-
-    println!();
-    println!(
-        "The backup at {} still contains the plaintext secret.",
-        backup.display()
-    );
-    println!("After verifying with `mde-cli credentials status`, delete it:");
-    println!("    rm {}", backup.display());
-
-    Ok(())
+/// Helper used when an atomic_replace / backup-write step fails after we
+/// have already written to the credential store. Rolls the Keychain entry
+/// back and returns a fully-formatted AppError so the call site can
+/// short-circuit with `?`.
+fn rollback_and_fail(
+    store: &dyn CredentialStore,
+    canonical: &Path,
+    cause: &str,
+    backup: Option<&Path>,
+) -> Result<(), AppError> {
+    let rb = store.delete(KEY_CLIENT_SECRET);
+    let rb_msg = match rb {
+        Ok(()) => "credential store entry rolled back".to_string(),
+        Err(re) => format!(
+            "WARNING: failed to roll back credential store entry: {}",
+            re
+        ),
+    };
+    let extra = match backup {
+        Some(p) => format!(" Backup at {} also contains the plaintext.", p.display()),
+        None => String::new(),
+    };
+    Err(AppError::Config(format!(
+        "failed to update {}: {}. {}. The plaintext secret is still in {}.{}",
+        canonical.display(),
+        cause,
+        rb_msg,
+        canonical.display(),
+        extra,
+    )))
 }
 
 /// Write `bytes` to `path` with mode 0o600. When `exclusive` is true, fails
@@ -326,21 +416,23 @@ fn extract_client_secret(content: &str) -> SecretScan {
     SecretScan::Absent
 }
 
-/// Replace `client_secret = "..."` with `client_secret = ""` while preserving
-/// the rest of the file (comments, ordering, other fields). Only a true
+/// Remove the `client_secret = "..."` line entirely while preserving the
+/// rest of the file (comments, ordering, other fields). Only a true
 /// `client_secret` key is matched — `client_secret_extra` and similar are
 /// left untouched.
-fn blank_client_secret(content: &str) -> String {
+///
+/// We delete the line rather than blanking the value because a blanked
+/// `client_secret = ""` is itself a footgun: a future reader might think
+/// the empty string is an intentional override and wonder where the real
+/// value lives. A missing key makes the toml's role as "non-secret config"
+/// unambiguous.
+fn remove_client_secret_line(content: &str) -> String {
     let mut out = String::with_capacity(content.len());
     for line in content.lines() {
         let trimmed = line.trim_start();
         if let Some(rest) = trimmed.strip_prefix("client_secret") {
             let after = rest.trim_start();
             if after.starts_with('=') {
-                let indent_len = line.len() - trimmed.len();
-                out.push_str(&line[..indent_len]);
-                out.push_str("client_secret = \"\"");
-                out.push('\n');
                 continue;
             }
         }
@@ -408,15 +500,19 @@ client_id = "c"
     }
 
     #[test]
-    fn blank_replaces_only_client_secret_line() {
+    fn remove_drops_only_client_secret_line() {
         let s = r#"# comment
 [credentials]
 tenant_id = "t"
 client_secret = "abc123"
 client_id = "c"
 "#;
-        let out = blank_client_secret(s);
-        assert!(out.contains("client_secret = \"\""));
+        let out = remove_client_secret_line(s);
+        assert!(
+            !out.contains("client_secret"),
+            "client_secret remained: {}",
+            out
+        );
         assert!(!out.contains("abc123"));
         assert!(out.contains("# comment"));
         assert!(out.contains("tenant_id = \"t\""));
@@ -424,16 +520,16 @@ client_id = "c"
     }
 
     #[test]
-    fn blank_preserves_indentation() {
-        let s = "  client_secret = \"x\"\n";
-        let out = blank_client_secret(s);
-        assert_eq!(out, "  client_secret = \"\"\n");
+    fn remove_works_with_indented_key() {
+        let s = "  client_secret = \"x\"\nother = 1\n";
+        let out = remove_client_secret_line(s);
+        assert_eq!(out, "other = 1\n");
     }
 
     #[test]
-    fn blank_does_not_touch_similarly_named_keys() {
+    fn remove_does_not_touch_similarly_named_keys() {
         let s = "client_secret_extra = \"x\"\n";
-        let out = blank_client_secret(s);
+        let out = remove_client_secret_line(s);
         assert_eq!(out, "client_secret_extra = \"x\"\n");
     }
 

--- a/src/commands/credentials.rs
+++ b/src/commands/credentials.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::cli::credentials::{CredentialField, CredentialsCommand};
-use crate::config::credential_store::{ACCOUNT_CLIENT_SECRET, CredentialStore, default_store};
+use crate::config::credential_store::{CredentialStore, KEY_CLIENT_SECRET, default_store};
 use crate::error::AppError;
 
 /// File mode for any artifact that may contain plaintext credentials.
@@ -45,7 +45,7 @@ fn set_value(
         }
         trimmed
     } else {
-        let prompt = format!("Enter {} (input hidden): ", field.account());
+        let prompt = format!("Enter {} (input hidden): ", field.key());
         rpassword::prompt_password(prompt)
             .map_err(|e| AppError::Config(format!("failed to read password: {}", e)))?
     };
@@ -55,29 +55,30 @@ fn set_value(
     }
 
     store
-        .set(field.account(), &value)
+        .set(field.key(), &value)
         .map_err(|e| AppError::Config(e.to_string()))?;
-    println!("✅ Stored {} in credential store", field.account());
+    println!("✅ Stored {} in credential store", field.key());
     Ok(())
 }
 
 fn delete_value(store: &dyn CredentialStore, field: CredentialField) -> Result<(), AppError> {
     store
-        .delete(field.account())
+        .delete(field.key())
         .map_err(|e| AppError::Config(e.to_string()))?;
-    println!("✅ Deleted {} from credential store", field.account());
+    println!("✅ Deleted {} from credential store", field.key());
     Ok(())
 }
 
 fn print_status(store: &dyn CredentialStore) -> Result<(), AppError> {
-    // Probe each known field; report presence only, never the value.
-    let fields = [(CredentialField::ClientSecret, ACCOUNT_CLIENT_SECRET)];
+    // Probe each known field. We print only the field's static key (e.g.
+    // "client_secret") and a presence flag — never the credential value.
+    let keys = [KEY_CLIENT_SECRET];
     println!("Credential store: macOS Keychain (service=dev.mde-cli)");
-    for (_, account) in fields {
-        match store.get(account) {
-            Ok(Some(_)) => println!("  {} : stored", account),
-            Ok(None) => println!("  {} : not stored", account),
-            Err(e) => println!("  {} : error ({})", account, e),
+    for key in keys {
+        match store.get(key) {
+            Ok(Some(_)) => println!("  {} : stored", key),
+            Ok(None) => println!("  {} : not stored", key),
+            Err(e) => println!("  {} : error ({})", key, e),
         }
     }
     Ok(())
@@ -142,7 +143,7 @@ fn migrate(store: &dyn CredentialStore, dry_run: bool) -> Result<(), AppError> {
     println!("Backup written (mode 0600): {}", backup.display());
 
     store
-        .set(ACCOUNT_CLIENT_SECRET, &secret)
+        .set(KEY_CLIENT_SECRET, &secret)
         .map_err(|e| AppError::Config(format!("credential store: {}", e)))?;
     println!("Stored client_secret in credential store");
 
@@ -153,7 +154,7 @@ fn migrate(store: &dyn CredentialStore, dry_run: bool) -> Result<(), AppError> {
     if let Err(e) = atomic_replace(&path, updated.as_bytes()) {
         // Roll back the Keychain entry we just wrote, then surface a
         // detailed error so the user knows where the secret lives now.
-        let rb = store.delete(ACCOUNT_CLIENT_SECRET);
+        let rb = store.delete(KEY_CLIENT_SECRET);
         let rb_msg = match rb {
             Ok(()) => "credential store entry rolled back".to_string(),
             Err(re) => format!(

--- a/src/commands/credentials.rs
+++ b/src/commands/credentials.rs
@@ -508,11 +508,10 @@ client_secret = "abc123"
 client_id = "c"
 "#;
         let out = remove_client_secret_line(s);
-        assert!(
-            !out.contains("client_secret"),
-            "client_secret remained: {}",
-            out
-        );
+        // Don't include `out` in the assert message: CodeQL flags
+        // formatting a function-of-secret-shaped-input into a diagnostic
+        // string, even though this is a test fixture.
+        assert!(!out.contains("client_secret"));
         assert!(!out.contains("abc123"));
         assert!(out.contains("# comment"));
         assert!(out.contains("tenant_id = \"t\""));

--- a/src/commands/credentials.rs
+++ b/src/commands/credentials.rs
@@ -1,11 +1,15 @@
-use std::fs;
+use std::fs::{self, File, OpenOptions};
 use std::io::{self, Write};
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::cli::credentials::{CredentialField, CredentialsCommand};
 use crate::config::credential_store::{ACCOUNT_CLIENT_SECRET, CredentialStore, default_store};
 use crate::error::AppError;
+
+/// File mode for any artifact that may contain plaintext credentials.
+const SECRET_FILE_MODE: u32 = 0o600;
 
 pub fn handle(cmd: &CredentialsCommand) -> Result<(), AppError> {
     let store = default_store().ok_or_else(|| {
@@ -33,7 +37,9 @@ fn set_value(
         io::stdin()
             .read_line(&mut buf)
             .map_err(|e| AppError::Config(format!("failed to read stdin: {}", e)))?;
-        let trimmed = buf.trim_end_matches(['\r', '\n']).to_string();
+        // Trim full whitespace (not just CRLF) so a stray trailing space
+        // pasted from a password manager does not silently corrupt the secret.
+        let trimmed = buf.trim().to_string();
         if trimmed.is_empty() {
             return Err(AppError::InvalidInput("empty value from stdin".to_string()));
         }
@@ -80,17 +86,27 @@ fn print_status(store: &dyn CredentialStore) -> Result<(), AppError> {
 fn migrate(store: &dyn CredentialStore, dry_run: bool) -> Result<(), AppError> {
     let path = find_credentials_toml()
         .ok_or_else(|| AppError::Config("no credentials.toml found to migrate from".to_string()))?;
-    println!("Found credentials.toml: {}", path.display());
+    // Resolve to canonical path so the user sees what we will actually
+    // mutate, not a relative path that could be interpreted as something
+    // surprising (e.g. `.mde-credentials.toml` in cwd).
+    let canonical = fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+    println!("Found credentials.toml: {}", canonical.display());
 
     let original = fs::read_to_string(&path)
-        .map_err(|e| AppError::Config(format!("failed to read {}: {}", path.display(), e)))?;
+        .map_err(|e| AppError::Config(format!("failed to read {}: {}", canonical.display(), e)))?;
 
-    let secret = extract_client_secret(&original);
-    let secret = match secret {
-        Some(s) if !s.is_empty() => s,
-        _ => {
+    let secret = match extract_client_secret(&original) {
+        SecretScan::Present(s) => s,
+        SecretScan::Absent => {
             println!("  client_secret: not present (nothing to migrate)");
             return Ok(());
+        }
+        SecretScan::Unsupported(form) => {
+            return Err(AppError::Config(format!(
+                "client_secret uses an unsupported quoting form ({}); refusing to rewrite. \
+                 Convert it to `client_secret = \"...\"` form and retry.",
+                form
+            )));
         }
     };
     println!("  client_secret: present (will move to credential store)");
@@ -100,8 +116,12 @@ fn migrate(store: &dyn CredentialStore, dry_run: bool) -> Result<(), AppError> {
         return Ok(());
     }
 
-    // Confirm before mutating.
-    print!("Migrate client_secret to the credential store? [y/N]: ");
+    // Confirm before mutating. Echo the canonical path again so a hostile
+    // cwd cannot smuggle in a different file between the find and the prompt.
+    print!(
+        "Migrate client_secret from {} to the credential store? [y/N]: ",
+        canonical.display()
+    );
     io::stdout()
         .flush()
         .map_err(|e| AppError::Config(format!("flush stdout: {}", e)))?;
@@ -114,31 +134,105 @@ fn migrate(store: &dyn CredentialStore, dry_run: bool) -> Result<(), AppError> {
         return Ok(());
     }
 
-    // Backup before mutating the file.
+    // Backup with restrictive permissions (0o600). `fs::copy` would inherit
+    // the source mode, which is commonly 0o644 — leaving the plaintext
+    // backup world-readable. Use create_new + 0o600 + manual byte copy.
     let backup = backup_path(&path);
-    fs::copy(&path, &backup)
-        .map_err(|e| AppError::Config(format!("failed to write backup: {}", e)))?;
-    println!("Backup written: {}", backup.display());
+    write_secret_file(&backup, original.as_bytes(), true)?;
+    println!("Backup written (mode 0600): {}", backup.display());
 
     store
         .set(ACCOUNT_CLIENT_SECRET, &secret)
         .map_err(|e| AppError::Config(format!("credential store: {}", e)))?;
-    println!("✅ Stored client_secret in credential store");
+    println!("Stored client_secret in credential store");
 
+    // Atomic rewrite: write to a sibling tempfile then rename(). If anything
+    // fails, the original file is untouched and we roll back the Keychain
+    // write so the user is not left in an inconsistent half-migrated state.
     let updated = blank_client_secret(&original);
-    fs::write(&path, updated)
-        .map_err(|e| AppError::Config(format!("failed to update {}: {}", path.display(), e)))?;
-    println!("✅ Cleared client_secret in {}", path.display());
+    if let Err(e) = atomic_replace(&path, updated.as_bytes()) {
+        // Roll back the Keychain entry we just wrote, then surface a
+        // detailed error so the user knows where the secret lives now.
+        let rb = store.delete(ACCOUNT_CLIENT_SECRET);
+        let rb_msg = match rb {
+            Ok(()) => "credential store entry rolled back".to_string(),
+            Err(re) => format!(
+                "WARNING: failed to roll back credential store entry: {}",
+                re
+            ),
+        };
+        return Err(AppError::Config(format!(
+            "failed to update {}: {}. {}. The plaintext secret is still in {} and {}.",
+            canonical.display(),
+            e,
+            rb_msg,
+            canonical.display(),
+            backup.display(),
+        )));
+    }
+    println!("Cleared client_secret in {}", canonical.display());
 
     println!();
     println!(
-        "⚠ The backup at {} still contains the plaintext secret.",
+        "The backup at {} still contains the plaintext secret.",
         backup.display()
     );
-    println!("  After verifying with `mde-cli credentials status`, delete it:");
+    println!("After verifying with `mde-cli credentials status`, delete it:");
     println!("    rm {}", backup.display());
 
     Ok(())
+}
+
+/// Write `bytes` to `path` with mode 0o600. When `exclusive` is true, fails
+/// if the path already exists — used for backups so we never clobber an
+/// older backup that the user might still need.
+fn write_secret_file(path: &Path, bytes: &[u8], exclusive: bool) -> Result<(), AppError> {
+    let mut opts = OpenOptions::new();
+    opts.write(true).mode(SECRET_FILE_MODE);
+    if exclusive {
+        opts.create_new(true);
+    } else {
+        opts.create(true).truncate(true);
+    }
+    let mut f: File = opts
+        .open(path)
+        .map_err(|e| AppError::Config(format!("open {}: {}", path.display(), e)))?;
+    f.write_all(bytes)
+        .map_err(|e| AppError::Config(format!("write {}: {}", path.display(), e)))?;
+    // Belt and suspenders: explicitly set mode in case the FS ignored the
+    // open-time mode (some networked filesystems do).
+    let _ = fs::set_permissions(path, fs::Permissions::from_mode(SECRET_FILE_MODE));
+    Ok(())
+}
+
+/// Replace `path` with `bytes` atomically: write a sibling tempfile with
+/// 0o600 then `rename` over the original. The mode of the resulting file
+/// is the mode of the tempfile (0o600), which is more restrictive than the
+/// previous mode and therefore safe.
+fn atomic_replace(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let mut name = path.file_name().unwrap_or_default().to_os_string();
+    name.push(format!(".tmp.{}", ts));
+    let tmp = dir.join(name);
+
+    {
+        let mut f = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(SECRET_FILE_MODE)
+            .open(&tmp)?;
+        f.write_all(bytes)?;
+        f.sync_all().ok();
+    }
+    let _ = fs::set_permissions(&tmp, fs::Permissions::from_mode(SECRET_FILE_MODE));
+    fs::rename(&tmp, path).inspect_err(|_| {
+        // Best-effort cleanup of the tempfile if rename fails.
+        let _ = fs::remove_file(&tmp);
+    })
 }
 
 fn find_credentials_toml() -> Option<PathBuf> {
@@ -175,37 +269,81 @@ fn backup_path(p: &Path) -> PathBuf {
     p.with_file_name(name)
 }
 
-/// Extract the value of `client_secret = "..."` from a credentials.toml.
-/// Uses a minimal text scan rather than full TOML re-serialization so that
-/// formatting and comments in the user's file are preserved on rewrite.
-fn extract_client_secret(content: &str) -> Option<String> {
+/// Outcome of scanning a credentials.toml for `client_secret`.
+#[derive(Debug, PartialEq, Eq)]
+enum SecretScan {
+    /// Field is absent or set to an empty basic string.
+    Absent,
+    /// Field is present and stored as `client_secret = "..."` (single-line basic).
+    Present(String),
+    /// Field is present but uses a quoting form we refuse to rewrite
+    /// (literal strings, multi-line basic, multi-line literal). We bail out
+    /// rather than risk a partial migration where extract returns None but
+    /// blank_client_secret would still wipe the line.
+    Unsupported(&'static str),
+}
+
+/// Scan a credentials.toml line-by-line for `client_secret`. We avoid a full
+/// TOML round-trip so the user's formatting and comments survive rewrite.
+fn extract_client_secret(content: &str) -> SecretScan {
     for line in content.lines() {
         let trimmed = line.trim_start();
-        if let Some(rest) = trimmed.strip_prefix("client_secret") {
-            let rest = rest.trim_start();
-            let rest = rest.strip_prefix('=')?.trim_start();
-            // Accept "..." form only; reject multi-line basic strings for safety.
-            let rest = rest.strip_prefix('"')?;
-            let end = rest.find('"')?;
-            return Some(rest[..end].to_string());
+        // Word-boundary match: rule out `client_secret_extra` etc.
+        let Some(rest) = trimmed.strip_prefix("client_secret") else {
+            continue;
+        };
+        let after_key = rest.trim_start();
+        if !after_key.starts_with('=') {
+            continue;
         }
+        let value_part = after_key[1..].trim_start();
+
+        if value_part.starts_with("\"\"\"") {
+            return SecretScan::Unsupported("multi-line basic string (\"\"\"...\"\"\")");
+        }
+        if value_part.starts_with("'''") {
+            return SecretScan::Unsupported("multi-line literal string ('''...''')");
+        }
+        if value_part.starts_with('\'') {
+            return SecretScan::Unsupported("literal string ('...')");
+        }
+        if let Some(rest) = value_part.strip_prefix('"') {
+            // Find the closing quote. Reject embedded escaped quotes for now
+            // (TOML allows `\"`); they are not produced by typical templates,
+            // and refusing them is safer than a half-correct parse.
+            if rest.contains("\\\"") {
+                return SecretScan::Unsupported("basic string with escaped quotes");
+            }
+            return match rest.find('"') {
+                Some(0) => SecretScan::Absent,
+                Some(end) => SecretScan::Present(rest[..end].to_string()),
+                None => SecretScan::Unsupported("unterminated basic string"),
+            };
+        }
+        return SecretScan::Unsupported("unrecognized value form");
     }
-    None
+    SecretScan::Absent
 }
 
 /// Replace `client_secret = "..."` with `client_secret = ""` while preserving
-/// the rest of the file (comments, ordering, other fields).
+/// the rest of the file (comments, ordering, other fields). Only a true
+/// `client_secret` key is matched — `client_secret_extra` and similar are
+/// left untouched.
 fn blank_client_secret(content: &str) -> String {
     let mut out = String::with_capacity(content.len());
     for line in content.lines() {
         let trimmed = line.trim_start();
-        if trimmed.starts_with("client_secret") {
-            let indent_len = line.len() - trimmed.len();
-            out.push_str(&line[..indent_len]);
-            out.push_str("client_secret = \"\"");
-        } else {
-            out.push_str(line);
+        if let Some(rest) = trimmed.strip_prefix("client_secret") {
+            let after = rest.trim_start();
+            if after.starts_with('=') {
+                let indent_len = line.len() - trimmed.len();
+                out.push_str(&line[..indent_len]);
+                out.push_str("client_secret = \"\"");
+                out.push('\n');
+                continue;
+            }
         }
+        out.push_str(line);
         out.push('\n');
     }
     out
@@ -223,16 +361,49 @@ tenant_id = "t"
 client_secret = "abc123"
 client_id = "c"
 "#;
-        assert_eq!(extract_client_secret(s).as_deref(), Some("abc123"));
+        assert_eq!(
+            extract_client_secret(s),
+            SecretScan::Present("abc123".to_string())
+        );
     }
 
     #[test]
-    fn extract_returns_none_when_missing() {
+    fn extract_returns_absent_when_missing() {
         let s = r#"
 [credentials]
 client_id = "c"
 "#;
-        assert!(extract_client_secret(s).is_none());
+        assert_eq!(extract_client_secret(s), SecretScan::Absent);
+    }
+
+    #[test]
+    fn extract_returns_absent_for_empty_basic_string() {
+        let s = "client_secret = \"\"\n";
+        assert_eq!(extract_client_secret(s), SecretScan::Absent);
+    }
+
+    #[test]
+    fn extract_rejects_literal_string() {
+        let s = "client_secret = 'abc'\n";
+        assert!(matches!(
+            extract_client_secret(s),
+            SecretScan::Unsupported(_)
+        ));
+    }
+
+    #[test]
+    fn extract_rejects_multiline_basic() {
+        let s = "client_secret = \"\"\"abc\"\"\"\n";
+        assert!(matches!(
+            extract_client_secret(s),
+            SecretScan::Unsupported(_)
+        ));
+    }
+
+    #[test]
+    fn extract_ignores_similarly_named_keys() {
+        let s = "client_secret_extra = \"x\"\n";
+        assert_eq!(extract_client_secret(s), SecretScan::Absent);
     }
 
     #[test]
@@ -256,5 +427,48 @@ client_id = "c"
         let s = "  client_secret = \"x\"\n";
         let out = blank_client_secret(s);
         assert_eq!(out, "  client_secret = \"\"\n");
+    }
+
+    #[test]
+    fn blank_does_not_touch_similarly_named_keys() {
+        let s = "client_secret_extra = \"x\"\n";
+        let out = blank_client_secret(s);
+        assert_eq!(out, "client_secret_extra = \"x\"\n");
+    }
+
+    #[test]
+    fn atomic_replace_writes_with_mode_0600() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("creds.toml");
+        std::fs::write(&path, "old\n").unwrap();
+        // Make the original world-readable to prove atomic_replace tightens it.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        atomic_replace(&path, b"new\n").unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "new\n");
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "atomic_replace must produce 0600, got {:o}",
+            mode
+        );
+    }
+
+    #[test]
+    fn write_secret_file_creates_0600() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("backup");
+        write_secret_file(&path, b"secret\n", true).unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[test]
+    fn write_secret_file_exclusive_refuses_overwrite() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("backup");
+        std::fs::write(&path, b"existing").unwrap();
+        let err = write_secret_file(&path, b"new", true).unwrap_err();
+        let msg = format!("{}", err);
+        assert!(msg.contains("open"), "unexpected error: {}", msg);
     }
 }

--- a/src/commands/credentials.rs
+++ b/src/commands/credentials.rs
@@ -1,0 +1,260 @@
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::cli::credentials::{CredentialField, CredentialsCommand};
+use crate::config::credential_store::{ACCOUNT_CLIENT_SECRET, CredentialStore, default_store};
+use crate::error::AppError;
+
+pub fn handle(cmd: &CredentialsCommand) -> Result<(), AppError> {
+    let store = default_store().ok_or_else(|| {
+        AppError::Config(
+            "no credential store backend available on this platform (macOS Keychain required)"
+                .to_string(),
+        )
+    })?;
+
+    match cmd {
+        CredentialsCommand::Set { field, stdin } => set_value(store.as_ref(), *field, *stdin),
+        CredentialsCommand::Delete { field } => delete_value(store.as_ref(), *field),
+        CredentialsCommand::Status => print_status(store.as_ref()),
+        CredentialsCommand::Migrate { dry_run } => migrate(store.as_ref(), *dry_run),
+    }
+}
+
+fn set_value(
+    store: &dyn CredentialStore,
+    field: CredentialField,
+    from_stdin: bool,
+) -> Result<(), AppError> {
+    let value = if from_stdin {
+        let mut buf = String::new();
+        io::stdin()
+            .read_line(&mut buf)
+            .map_err(|e| AppError::Config(format!("failed to read stdin: {}", e)))?;
+        let trimmed = buf.trim_end_matches(['\r', '\n']).to_string();
+        if trimmed.is_empty() {
+            return Err(AppError::InvalidInput("empty value from stdin".to_string()));
+        }
+        trimmed
+    } else {
+        let prompt = format!("Enter {} (input hidden): ", field.account());
+        rpassword::prompt_password(prompt)
+            .map_err(|e| AppError::Config(format!("failed to read password: {}", e)))?
+    };
+
+    if value.is_empty() {
+        return Err(AppError::InvalidInput("empty value".to_string()));
+    }
+
+    store
+        .set(field.account(), &value)
+        .map_err(|e| AppError::Config(e.to_string()))?;
+    println!("✅ Stored {} in credential store", field.account());
+    Ok(())
+}
+
+fn delete_value(store: &dyn CredentialStore, field: CredentialField) -> Result<(), AppError> {
+    store
+        .delete(field.account())
+        .map_err(|e| AppError::Config(e.to_string()))?;
+    println!("✅ Deleted {} from credential store", field.account());
+    Ok(())
+}
+
+fn print_status(store: &dyn CredentialStore) -> Result<(), AppError> {
+    // Probe each known field; report presence only, never the value.
+    let fields = [(CredentialField::ClientSecret, ACCOUNT_CLIENT_SECRET)];
+    println!("Credential store: macOS Keychain (service=dev.mde-cli)");
+    for (_, account) in fields {
+        match store.get(account) {
+            Ok(Some(_)) => println!("  {} : stored", account),
+            Ok(None) => println!("  {} : not stored", account),
+            Err(e) => println!("  {} : error ({})", account, e),
+        }
+    }
+    Ok(())
+}
+
+fn migrate(store: &dyn CredentialStore, dry_run: bool) -> Result<(), AppError> {
+    let path = find_credentials_toml()
+        .ok_or_else(|| AppError::Config("no credentials.toml found to migrate from".to_string()))?;
+    println!("Found credentials.toml: {}", path.display());
+
+    let original = fs::read_to_string(&path)
+        .map_err(|e| AppError::Config(format!("failed to read {}: {}", path.display(), e)))?;
+
+    let secret = extract_client_secret(&original);
+    let secret = match secret {
+        Some(s) if !s.is_empty() => s,
+        _ => {
+            println!("  client_secret: not present (nothing to migrate)");
+            return Ok(());
+        }
+    };
+    println!("  client_secret: present (will move to credential store)");
+
+    if dry_run {
+        println!("(dry-run) no changes made");
+        return Ok(());
+    }
+
+    // Confirm before mutating.
+    print!("Migrate client_secret to the credential store? [y/N]: ");
+    io::stdout()
+        .flush()
+        .map_err(|e| AppError::Config(format!("flush stdout: {}", e)))?;
+    let mut answer = String::new();
+    io::stdin()
+        .read_line(&mut answer)
+        .map_err(|e| AppError::Config(format!("read stdin: {}", e)))?;
+    if !matches!(answer.trim(), "y" | "Y" | "yes") {
+        println!("Aborted.");
+        return Ok(());
+    }
+
+    // Backup before mutating the file.
+    let backup = backup_path(&path);
+    fs::copy(&path, &backup)
+        .map_err(|e| AppError::Config(format!("failed to write backup: {}", e)))?;
+    println!("Backup written: {}", backup.display());
+
+    store
+        .set(ACCOUNT_CLIENT_SECRET, &secret)
+        .map_err(|e| AppError::Config(format!("credential store: {}", e)))?;
+    println!("✅ Stored client_secret in credential store");
+
+    let updated = blank_client_secret(&original);
+    fs::write(&path, updated)
+        .map_err(|e| AppError::Config(format!("failed to update {}: {}", path.display(), e)))?;
+    println!("✅ Cleared client_secret in {}", path.display());
+
+    println!();
+    println!(
+        "⚠ The backup at {} still contains the plaintext secret.",
+        backup.display()
+    );
+    println!("  After verifying with `mde-cli credentials status`, delete it:");
+    println!("    rm {}", backup.display());
+
+    Ok(())
+}
+
+fn find_credentials_toml() -> Option<PathBuf> {
+    let candidates = credentials_search_paths();
+    candidates.into_iter().find(|p| p.is_file())
+}
+
+fn credentials_search_paths() -> Vec<PathBuf> {
+    let mut paths = vec![PathBuf::from(".mde-credentials.toml")];
+    if let Ok(config_home) = std::env::var("XDG_CONFIG_HOME") {
+        paths.push(
+            PathBuf::from(config_home)
+                .join("mde")
+                .join("credentials.toml"),
+        );
+    } else if let Ok(home) = std::env::var("HOME") {
+        paths.push(
+            PathBuf::from(home)
+                .join(".config")
+                .join("mde")
+                .join("credentials.toml"),
+        );
+    }
+    paths
+}
+
+fn backup_path(p: &Path) -> PathBuf {
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let mut name = p.file_name().unwrap_or_default().to_os_string();
+    name.push(format!(".bak.{}", ts));
+    p.with_file_name(name)
+}
+
+/// Extract the value of `client_secret = "..."` from a credentials.toml.
+/// Uses a minimal text scan rather than full TOML re-serialization so that
+/// formatting and comments in the user's file are preserved on rewrite.
+fn extract_client_secret(content: &str) -> Option<String> {
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        if let Some(rest) = trimmed.strip_prefix("client_secret") {
+            let rest = rest.trim_start();
+            let rest = rest.strip_prefix('=')?.trim_start();
+            // Accept "..." form only; reject multi-line basic strings for safety.
+            let rest = rest.strip_prefix('"')?;
+            let end = rest.find('"')?;
+            return Some(rest[..end].to_string());
+        }
+    }
+    None
+}
+
+/// Replace `client_secret = "..."` with `client_secret = ""` while preserving
+/// the rest of the file (comments, ordering, other fields).
+fn blank_client_secret(content: &str) -> String {
+    let mut out = String::with_capacity(content.len());
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("client_secret") {
+            let indent_len = line.len() - trimmed.len();
+            out.push_str(&line[..indent_len]);
+            out.push_str("client_secret = \"\"");
+        } else {
+            out.push_str(line);
+        }
+        out.push('\n');
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_quoted_value() {
+        let s = r#"
+[credentials]
+tenant_id = "t"
+client_secret = "abc123"
+client_id = "c"
+"#;
+        assert_eq!(extract_client_secret(s).as_deref(), Some("abc123"));
+    }
+
+    #[test]
+    fn extract_returns_none_when_missing() {
+        let s = r#"
+[credentials]
+client_id = "c"
+"#;
+        assert!(extract_client_secret(s).is_none());
+    }
+
+    #[test]
+    fn blank_replaces_only_client_secret_line() {
+        let s = r#"# comment
+[credentials]
+tenant_id = "t"
+client_secret = "abc123"
+client_id = "c"
+"#;
+        let out = blank_client_secret(s);
+        assert!(out.contains("client_secret = \"\""));
+        assert!(!out.contains("abc123"));
+        assert!(out.contains("# comment"));
+        assert!(out.contains("tenant_id = \"t\""));
+        assert!(out.contains("client_id = \"c\""));
+    }
+
+    #[test]
+    fn blank_preserves_indentation() {
+        let s = "  client_secret = \"x\"\n";
+        let out = blank_client_secret(s);
+        assert_eq!(out, "  client_secret = \"\"\n");
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod alerts;
 pub mod auth;
+pub mod credentials;
 pub mod hunting;
 pub mod incidents;
 pub mod machines;

--- a/src/config/credential_store.rs
+++ b/src/config/credential_store.rs
@@ -1,0 +1,173 @@
+use std::fmt;
+
+/// Service identifier used as the Keychain "service" attribute.
+/// Acts as a namespace so credentials do not collide with other apps.
+pub const SERVICE: &str = "dev.mde-cli";
+
+/// Account names (Keychain "account" attribute) for each credential field.
+pub const ACCOUNT_CLIENT_SECRET: &str = "client_secret";
+
+#[derive(Debug)]
+pub enum StoreError {
+    /// The backend (e.g. Keychain) is not available on this platform.
+    Unavailable(String),
+    /// An I/O or backend error occurred while accessing the store.
+    Backend(String),
+}
+
+impl fmt::Display for StoreError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            StoreError::Unavailable(s) => write!(f, "credential store unavailable: {}", s),
+            StoreError::Backend(s) => write!(f, "credential store error: {}", s),
+        }
+    }
+}
+
+impl std::error::Error for StoreError {}
+
+/// Abstract storage backend for sensitive credentials.
+///
+/// `get` returns `Ok(None)` when the entry simply does not exist (a normal
+/// state during fallback to the next source). Backend-level failures must
+/// be surfaced as `Err` so callers can distinguish "not stored" from
+/// "store unreachable".
+pub trait CredentialStore {
+    fn get(&self, account: &str) -> Result<Option<String>, StoreError>;
+    fn set(&self, account: &str, value: &str) -> Result<(), StoreError>;
+    fn delete(&self, account: &str) -> Result<(), StoreError>;
+}
+
+#[cfg(target_os = "macos")]
+mod keychain {
+    use super::{CredentialStore, SERVICE, StoreError};
+    use keyring::Entry;
+
+    pub struct KeychainStore;
+
+    impl KeychainStore {
+        pub fn new() -> Self {
+            Self
+        }
+
+        fn entry(account: &str) -> Result<Entry, StoreError> {
+            Entry::new(SERVICE, account).map_err(|e| StoreError::Backend(e.to_string()))
+        }
+    }
+
+    impl Default for KeychainStore {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl CredentialStore for KeychainStore {
+        fn get(&self, account: &str) -> Result<Option<String>, StoreError> {
+            let entry = Self::entry(account)?;
+            match entry.get_password() {
+                Ok(v) => Ok(Some(v)),
+                Err(keyring::Error::NoEntry) => Ok(None),
+                Err(e) => Err(StoreError::Backend(e.to_string())),
+            }
+        }
+
+        fn set(&self, account: &str, value: &str) -> Result<(), StoreError> {
+            let entry = Self::entry(account)?;
+            entry
+                .set_password(value)
+                .map_err(|e| StoreError::Backend(e.to_string()))
+        }
+
+        fn delete(&self, account: &str) -> Result<(), StoreError> {
+            let entry = Self::entry(account)?;
+            match entry.delete_credential() {
+                Ok(()) => Ok(()),
+                Err(keyring::Error::NoEntry) => Ok(()),
+                Err(e) => Err(StoreError::Backend(e.to_string())),
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub use keychain::KeychainStore;
+
+/// Returns the platform's default credential store, or `None` if no
+/// secure store backend is available on this build target.
+pub fn default_store() -> Option<Box<dyn CredentialStore>> {
+    #[cfg(target_os = "macos")]
+    {
+        Some(Box::new(KeychainStore::new()))
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        None
+    }
+}
+
+#[cfg(test)]
+pub mod test_support {
+    use super::{CredentialStore, StoreError};
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    /// In-memory `CredentialStore` used by tests.
+    pub struct MemoryStore {
+        inner: Mutex<HashMap<String, String>>,
+    }
+
+    impl MemoryStore {
+        pub fn new() -> Self {
+            Self {
+                inner: Mutex::new(HashMap::new()),
+            }
+        }
+    }
+
+    impl Default for MemoryStore {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl CredentialStore for MemoryStore {
+        fn get(&self, account: &str) -> Result<Option<String>, StoreError> {
+            Ok(self.inner.lock().unwrap().get(account).cloned())
+        }
+
+        fn set(&self, account: &str, value: &str) -> Result<(), StoreError> {
+            self.inner
+                .lock()
+                .unwrap()
+                .insert(account.to_string(), value.to_string());
+            Ok(())
+        }
+
+        fn delete(&self, account: &str) -> Result<(), StoreError> {
+            self.inner.lock().unwrap().remove(account);
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::MemoryStore;
+    use super::*;
+
+    #[test]
+    fn memory_store_roundtrip() {
+        let s = MemoryStore::new();
+        assert!(s.get("k").unwrap().is_none());
+        s.set("k", "v").unwrap();
+        assert_eq!(s.get("k").unwrap().as_deref(), Some("v"));
+        s.delete("k").unwrap();
+        assert!(s.get("k").unwrap().is_none());
+    }
+
+    #[test]
+    fn memory_store_delete_missing_is_ok() {
+        let s = MemoryStore::new();
+        s.delete("missing").unwrap();
+    }
+}

--- a/src/config/credential_store.rs
+++ b/src/config/credential_store.rs
@@ -67,15 +67,13 @@ mod keychain {
             match entry.get_password() {
                 Ok(v) => Ok(Some(v)),
                 Err(keyring::Error::NoEntry) => Ok(None),
-                Err(e) => Err(StoreError::Backend(e.to_string())),
+                Err(e) => Err(classify_keyring_err(e)),
             }
         }
 
         fn set(&self, account: &str, value: &str) -> Result<(), StoreError> {
             let entry = Self::entry(account)?;
-            entry
-                .set_password(value)
-                .map_err(|e| StoreError::Backend(e.to_string()))
+            entry.set_password(value).map_err(classify_keyring_err)
         }
 
         fn delete(&self, account: &str) -> Result<(), StoreError> {
@@ -83,8 +81,30 @@ mod keychain {
             match entry.delete_credential() {
                 Ok(()) => Ok(()),
                 Err(keyring::Error::NoEntry) => Ok(()),
-                Err(e) => Err(StoreError::Backend(e.to_string())),
+                Err(e) => Err(classify_keyring_err(e)),
             }
+        }
+    }
+
+    /// Classify a `keyring::Error` into `Unavailable` (the store as a whole
+    /// is not present, e.g. CI sandbox without a default keychain) vs
+    /// `Backend` (an actual access failure that the user should investigate
+    /// — denied prompt, daemon down, ACL mismatch).
+    ///
+    /// "default keychain could not be found" comes from
+    /// `Security.framework`'s `errSecNoDefaultKeychain` and means there is
+    /// nothing to read from at all; treating it as `Backend` would block
+    /// the toml fallback for users who never opted into the Keychain.
+    fn classify_keyring_err(e: keyring::Error) -> StoreError {
+        let msg = e.to_string();
+        let lower = msg.to_lowercase();
+        let unavailable = lower.contains("no default keychain")
+            || lower.contains("default keychain could not be found")
+            || lower.contains("no platform credential store");
+        if unavailable {
+            StoreError::Unavailable(msg)
+        } else {
+            StoreError::Backend(msg)
         }
     }
 }

--- a/src/config/credential_store.rs
+++ b/src/config/credential_store.rs
@@ -4,8 +4,10 @@ use std::fmt;
 /// Acts as a namespace so credentials do not collide with other apps.
 pub const SERVICE: &str = "dev.mde-cli";
 
-/// Account names (Keychain "account" attribute) for each credential field.
-pub const ACCOUNT_CLIENT_SECRET: &str = "client_secret";
+/// Logical identifier for the OAuth2 client_secret entry. This is the
+/// label / key used to look the entry up in the store; it is NOT the
+/// secret value itself.
+pub const KEY_CLIENT_SECRET: &str = "client_secret";
 
 #[derive(Debug)]
 pub enum StoreError {
@@ -28,14 +30,15 @@ impl std::error::Error for StoreError {}
 
 /// Abstract storage backend for sensitive credentials.
 ///
-/// `get` returns `Ok(None)` when the entry simply does not exist (a normal
-/// state during fallback to the next source). Backend-level failures must
-/// be surfaced as `Err` so callers can distinguish "not stored" from
-/// "store unreachable".
+/// `key` is the entry's identifier (e.g. "client_secret"), not the
+/// credential value. `get` returns `Ok(None)` when the entry simply does
+/// not exist (a normal state during fallback to the next source).
+/// Backend-level failures must be surfaced as `Err` so callers can
+/// distinguish "not stored" from "store unreachable".
 pub trait CredentialStore {
-    fn get(&self, account: &str) -> Result<Option<String>, StoreError>;
-    fn set(&self, account: &str, value: &str) -> Result<(), StoreError>;
-    fn delete(&self, account: &str) -> Result<(), StoreError>;
+    fn get(&self, key: &str) -> Result<Option<String>, StoreError>;
+    fn set(&self, key: &str, value: &str) -> Result<(), StoreError>;
+    fn delete(&self, key: &str) -> Result<(), StoreError>;
 }
 
 #[cfg(target_os = "macos")]
@@ -50,8 +53,10 @@ mod keychain {
             Self
         }
 
-        fn entry(account: &str) -> Result<Entry, StoreError> {
-            Entry::new(SERVICE, account).map_err(|e| StoreError::Backend(e.to_string()))
+        fn entry(key: &str) -> Result<Entry, StoreError> {
+            // The Keychain API names the second slot "account"; we use our
+            // logical key as the account string.
+            Entry::new(SERVICE, key).map_err(|e| StoreError::Backend(e.to_string()))
         }
     }
 
@@ -62,8 +67,8 @@ mod keychain {
     }
 
     impl CredentialStore for KeychainStore {
-        fn get(&self, account: &str) -> Result<Option<String>, StoreError> {
-            let entry = Self::entry(account)?;
+        fn get(&self, key: &str) -> Result<Option<String>, StoreError> {
+            let entry = Self::entry(key)?;
             match entry.get_password() {
                 Ok(v) => Ok(Some(v)),
                 Err(keyring::Error::NoEntry) => Ok(None),
@@ -71,13 +76,13 @@ mod keychain {
             }
         }
 
-        fn set(&self, account: &str, value: &str) -> Result<(), StoreError> {
-            let entry = Self::entry(account)?;
+        fn set(&self, key: &str, value: &str) -> Result<(), StoreError> {
+            let entry = Self::entry(key)?;
             entry.set_password(value).map_err(classify_keyring_err)
         }
 
-        fn delete(&self, account: &str) -> Result<(), StoreError> {
-            let entry = Self::entry(account)?;
+        fn delete(&self, key: &str) -> Result<(), StoreError> {
+            let entry = Self::entry(key)?;
             match entry.delete_credential() {
                 Ok(()) => Ok(()),
                 Err(keyring::Error::NoEntry) => Ok(()),
@@ -151,20 +156,20 @@ pub mod test_support {
     }
 
     impl CredentialStore for MemoryStore {
-        fn get(&self, account: &str) -> Result<Option<String>, StoreError> {
-            Ok(self.inner.lock().unwrap().get(account).cloned())
+        fn get(&self, key: &str) -> Result<Option<String>, StoreError> {
+            Ok(self.inner.lock().unwrap().get(key).cloned())
         }
 
-        fn set(&self, account: &str, value: &str) -> Result<(), StoreError> {
+        fn set(&self, key: &str, value: &str) -> Result<(), StoreError> {
             self.inner
                 .lock()
                 .unwrap()
-                .insert(account.to_string(), value.to_string());
+                .insert(key.to_string(), value.to_string());
             Ok(())
         }
 
-        fn delete(&self, account: &str) -> Result<(), StoreError> {
-            self.inner.lock().unwrap().remove(account);
+        fn delete(&self, key: &str) -> Result<(), StoreError> {
+            self.inner.lock().unwrap().remove(key);
             Ok(())
         }
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3,6 +3,10 @@ use std::path::PathBuf;
 
 use serde::Deserialize;
 
+pub mod credential_store;
+
+use credential_store::{ACCOUNT_CLIENT_SECRET, CredentialStore, default_store};
+
 const DEFAULT_MDE_BASE_URL: &str = "https://api.security.microsoft.com";
 const DEFAULT_GRAPH_BASE_URL: &str = "https://graph.microsoft.com";
 
@@ -26,6 +30,22 @@ struct CredentialsFile {
 /// (e.g. `client_id = ""`) do not bypass validation.
 fn non_empty(s: Option<String>) -> Option<String> {
     s.filter(|v| !v.is_empty())
+}
+
+/// Look up a secret in the credential store, treating backend failures as
+/// "not stored" (warned to stderr) so resolution falls through to the next source.
+fn read_secret_from_store(store: Option<&dyn CredentialStore>, account: &str) -> Option<String> {
+    let store = store?;
+    match store.get(account) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!(
+                "warning: credential store lookup failed for {}: {}",
+                account, e
+            );
+            None
+        }
+    }
 }
 
 /// Search paths for credentials.toml (highest priority first).
@@ -75,10 +95,10 @@ fn load_credentials_file() -> CredentialsFile {
 }
 
 /// Resolved MDE credentials collected from CLI args, environment variables,
-/// and credentials.toml.
+/// the OS credential store (e.g. macOS Keychain), and credentials.toml.
 /// Once constructed, the process should unset the MDE_* environment variables so that
 /// forked child processes (agent) do not inherit credentials via the environment.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct MdeCredentials {
     pub tenant_id: Option<String>,
     pub client_id: Option<String>,
@@ -86,6 +106,29 @@ pub struct MdeCredentials {
     pub access_token: Option<String>,
     pub mde_base_url: String,
     pub graph_base_url: String,
+}
+
+/// Custom `Debug` impl that masks `client_secret` and `access_token` so that
+/// accidental `dbg!` / `{:?}` formatting cannot leak secrets into logs or
+/// error messages.
+impl std::fmt::Debug for MdeCredentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MdeCredentials")
+            .field("tenant_id", &self.tenant_id)
+            .field("client_id", &self.client_id)
+            .field("client_secret", &mask(&self.client_secret))
+            .field("access_token", &mask(&self.access_token))
+            .field("mde_base_url", &self.mde_base_url)
+            .field("graph_base_url", &self.graph_base_url)
+            .finish()
+    }
+}
+
+fn mask(v: &Option<String>) -> &'static str {
+    match v {
+        Some(_) => "***",
+        None => "None",
+    }
 }
 
 impl Default for MdeCredentials {
@@ -102,9 +145,27 @@ impl Default for MdeCredentials {
 }
 
 impl MdeCredentials {
-    /// Resolve credentials from CLI args, environment variables, and credentials.toml.
-    /// Priority: CLI args > environment variables > credentials.toml > defaults.
+    /// Resolve credentials from CLI args, environment variables, the OS
+    /// credential store, and credentials.toml.
+    ///
+    /// Priority for `client_secret`:
+    ///   env var > Keychain > credentials.toml > None
+    /// Priority for `tenant_id` / `client_id`:
+    ///   CLI args > env var > credentials.toml > None
+    ///
+    /// Keychain access may prompt the user (macOS) on first use. Backend
+    /// errors are reported on stderr and treated as "not stored" so we fall
+    /// through to the next source rather than aborting startup.
     pub fn resolve(cli_tenant_id: Option<&str>, cli_client_id: Option<&str>) -> Self {
+        Self::resolve_with_store(cli_tenant_id, cli_client_id, default_store().as_deref())
+    }
+
+    /// Like `resolve` but with an injectable credential store (used in tests).
+    pub fn resolve_with_store(
+        cli_tenant_id: Option<&str>,
+        cli_client_id: Option<&str>,
+        store: Option<&dyn CredentialStore>,
+    ) -> Self {
         let file = load_credentials_file();
 
         let tenant_id = cli_tenant_id
@@ -119,6 +180,7 @@ impl MdeCredentials {
 
         let client_secret = std::env::var("MDE_CLIENT_SECRET")
             .ok()
+            .or_else(|| read_secret_from_store(store, ACCOUNT_CLIENT_SECRET))
             .or(file.client_secret);
 
         let access_token = std::env::var("MDE_ACCESS_TOKEN").ok();
@@ -242,6 +304,12 @@ unsafe fn overwrite_environ_value(name: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// Resolve-related tests mutate process-global env vars (HOME, XDG_CONFIG_HOME,
+    /// MDE_*) which makes them order-dependent under cargo test's default
+    /// thread-pool. Serialize them with a shared mutex.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_credentials_file_parse_full() {
@@ -383,6 +451,7 @@ client_secret = "toml-secret"
 
     #[test]
     fn test_mde_credentials_resolve_empty() {
+        let _lock = ENV_LOCK.lock().unwrap();
         unsafe { clear_mde_env() };
         with_isolated_credentials(|| {
             let creds = MdeCredentials::resolve(None, None);
@@ -397,6 +466,7 @@ client_secret = "toml-secret"
 
     #[test]
     fn test_mde_credentials_clear_env() {
+        let _lock = ENV_LOCK.lock().unwrap();
         // Set MDE env vars
         unsafe {
             std::env::set_var("MDE_TENANT_ID", "test-tenant");
@@ -441,6 +511,7 @@ client_secret = "toml-secret"
 
     #[test]
     fn test_mde_credentials_resolve_credentials_file_fallback() {
+        let _lock = ENV_LOCK.lock().unwrap();
         unsafe { clear_mde_env() };
         let toml_content = r#"
 [credentials]
@@ -462,6 +533,7 @@ graph_base_url = "https://custom.graph.example.com"
 
     #[test]
     fn test_mde_credentials_resolve_cli_overrides_credentials_file() {
+        let _lock = ENV_LOCK.lock().unwrap();
         unsafe { clear_mde_env() };
         let toml_content = r#"
 [credentials]
@@ -481,6 +553,7 @@ client_secret = "file-secret"
 
     #[test]
     fn test_mde_credentials_resolve_then_clear_env() {
+        let _lock = ENV_LOCK.lock().unwrap();
         with_isolated_credentials(|| {
             // Set env vars
             unsafe {
@@ -505,6 +578,67 @@ client_secret = "file-secret"
             // But env vars are gone
             assert!(std::env::var("MDE_TENANT_ID").is_err());
             assert!(std::env::var("MDE_CLIENT_SECRET").is_err());
+        });
+    }
+
+    #[test]
+    fn test_debug_masks_secrets() {
+        let creds = MdeCredentials {
+            tenant_id: Some("t".into()),
+            client_id: Some("c".into()),
+            client_secret: Some("super-secret".into()),
+            access_token: Some("super-token".into()),
+            ..Default::default()
+        };
+        let dbg = format!("{:?}", creds);
+        assert!(
+            !dbg.contains("super-secret"),
+            "client_secret leaked: {}",
+            dbg
+        );
+        assert!(!dbg.contains("super-token"), "access_token leaked: {}", dbg);
+        assert!(dbg.contains("***"));
+    }
+
+    #[test]
+    fn test_resolve_with_store_uses_keychain_when_no_env() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        unsafe { clear_mde_env() };
+        with_isolated_credentials(|| {
+            let store = credential_store::test_support::MemoryStore::new();
+            store.set(ACCOUNT_CLIENT_SECRET, "kc-secret").unwrap();
+            let creds = MdeCredentials::resolve_with_store(None, None, Some(&store));
+            assert_eq!(creds.client_secret.as_deref(), Some("kc-secret"));
+        });
+    }
+
+    #[test]
+    fn test_resolve_with_store_env_overrides_keychain() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        unsafe { clear_mde_env() };
+        with_isolated_credentials(|| {
+            unsafe { std::env::set_var("MDE_CLIENT_SECRET", "env-secret") };
+            let store = credential_store::test_support::MemoryStore::new();
+            store.set(ACCOUNT_CLIENT_SECRET, "kc-secret").unwrap();
+            let creds = MdeCredentials::resolve_with_store(None, None, Some(&store));
+            assert_eq!(creds.client_secret.as_deref(), Some("env-secret"));
+            unsafe { std::env::remove_var("MDE_CLIENT_SECRET") };
+        });
+    }
+
+    #[test]
+    fn test_resolve_with_store_falls_back_to_toml() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        unsafe { clear_mde_env() };
+        let toml_content = r#"
+[credentials]
+client_secret = "toml-secret"
+"#;
+        with_credentials_file(toml_content, || {
+            let store = credential_store::test_support::MemoryStore::new();
+            // Keychain empty -> falls through to TOML.
+            let creds = MdeCredentials::resolve_with_store(None, None, Some(&store));
+            assert_eq!(creds.client_secret.as_deref(), Some("toml-secret"));
         });
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 
 pub mod credential_store;
 
-use credential_store::{ACCOUNT_CLIENT_SECRET, CredentialStore, StoreError, default_store};
+use credential_store::{CredentialStore, KEY_CLIENT_SECRET, StoreError, default_store};
 
 const DEFAULT_MDE_BASE_URL: &str = "https://api.security.microsoft.com";
 const DEFAULT_GRAPH_BASE_URL: &str = "https://graph.microsoft.com";
@@ -48,18 +48,17 @@ enum StoreLookup {
     BackendError,
 }
 
-fn read_secret_from_store(store: Option<&dyn CredentialStore>, account: &str) -> StoreLookup {
+fn read_secret_from_store(store: Option<&dyn CredentialStore>, key: &str) -> StoreLookup {
     let Some(store) = store else {
         return StoreLookup::SkipFallthrough;
     };
-    match store.get(account) {
+    match store.get(key) {
         Ok(Some(v)) => StoreLookup::Found(v),
         Ok(None) => StoreLookup::NotStored,
         Err(StoreError::Unavailable(msg)) => {
-            eprintln!(
-                "warning: credential store unavailable for {}: {}",
-                account, msg
-            );
+            // `key` here is a static label like "client_secret", not the
+            // credential value. Log it for diagnostics.
+            eprintln!("warning: credential store unavailable for {}: {}", key, msg);
             StoreLookup::SkipFallthrough
         }
         Err(StoreError::Backend(msg)) => {
@@ -67,7 +66,7 @@ fn read_secret_from_store(store: Option<&dyn CredentialStore>, account: &str) ->
                 "error: credential store backend failure for {}: {}. \
                  Refusing to fall back to credentials.toml — fix the store \
                  access or unset the entry to make the toml fallback explicit.",
-                account, msg
+                key, msg
             );
             StoreLookup::BackendError
         }
@@ -205,7 +204,7 @@ impl MdeCredentials {
             .or(file.client_id);
 
         let client_secret = std::env::var("MDE_CLIENT_SECRET").ok().or_else(|| {
-            match read_secret_from_store(store, ACCOUNT_CLIENT_SECRET) {
+            match read_secret_from_store(store, KEY_CLIENT_SECRET) {
                 StoreLookup::Found(v) => Some(v),
                 // Backend failures: do NOT fall back to plaintext toml.
                 // Surface the missing secret to the caller, which will turn
@@ -639,7 +638,7 @@ client_secret = "file-secret"
         unsafe { clear_mde_env() };
         with_isolated_credentials(|| {
             let store = credential_store::test_support::MemoryStore::new();
-            store.set(ACCOUNT_CLIENT_SECRET, "kc-secret").unwrap();
+            store.set(KEY_CLIENT_SECRET, "kc-secret").unwrap();
             let creds = MdeCredentials::resolve_with_store(None, None, Some(&store));
             assert_eq!(creds.client_secret.as_deref(), Some("kc-secret"));
         });
@@ -652,7 +651,7 @@ client_secret = "file-secret"
         with_isolated_credentials(|| {
             unsafe { std::env::set_var("MDE_CLIENT_SECRET", "env-secret") };
             let store = credential_store::test_support::MemoryStore::new();
-            store.set(ACCOUNT_CLIENT_SECRET, "kc-secret").unwrap();
+            store.set(KEY_CLIENT_SECRET, "kc-secret").unwrap();
             let creds = MdeCredentials::resolve_with_store(None, None, Some(&store));
             assert_eq!(creds.client_secret.as_deref(), Some("env-secret"));
             unsafe { std::env::remove_var("MDE_CLIENT_SECRET") };

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 
 pub mod credential_store;
 
-use credential_store::{ACCOUNT_CLIENT_SECRET, CredentialStore, default_store};
+use credential_store::{ACCOUNT_CLIENT_SECRET, CredentialStore, StoreError, default_store};
 
 const DEFAULT_MDE_BASE_URL: &str = "https://api.security.microsoft.com";
 const DEFAULT_GRAPH_BASE_URL: &str = "https://graph.microsoft.com";
@@ -32,18 +32,44 @@ fn non_empty(s: Option<String>) -> Option<String> {
     s.filter(|v| !v.is_empty())
 }
 
-/// Look up a secret in the credential store, treating backend failures as
-/// "not stored" (warned to stderr) so resolution falls through to the next source.
-fn read_secret_from_store(store: Option<&dyn CredentialStore>, account: &str) -> Option<String> {
-    let store = store?;
+/// Result of consulting the credential store for a secret.
+enum StoreLookup {
+    /// No store, or store backend not available (non-macOS build, etc.).
+    /// Caller should fall through to the next source.
+    SkipFallthrough,
+    /// Store reports the secret is not stored. Fall through to the next source.
+    NotStored,
+    /// Store returned the secret value.
+    Found(String),
+    /// Backend error (e.g. user denied the Keychain prompt, daemon down).
+    /// Caller MUST NOT fall through to credentials.toml — silently picking
+    /// up a stale plaintext secret would defeat the point of moving the
+    /// secret into the Keychain in the first place.
+    BackendError,
+}
+
+fn read_secret_from_store(store: Option<&dyn CredentialStore>, account: &str) -> StoreLookup {
+    let Some(store) = store else {
+        return StoreLookup::SkipFallthrough;
+    };
     match store.get(account) {
-        Ok(v) => v,
-        Err(e) => {
+        Ok(Some(v)) => StoreLookup::Found(v),
+        Ok(None) => StoreLookup::NotStored,
+        Err(StoreError::Unavailable(msg)) => {
             eprintln!(
-                "warning: credential store lookup failed for {}: {}",
-                account, e
+                "warning: credential store unavailable for {}: {}",
+                account, msg
             );
-            None
+            StoreLookup::SkipFallthrough
+        }
+        Err(StoreError::Backend(msg)) => {
+            eprintln!(
+                "error: credential store backend failure for {}: {}. \
+                 Refusing to fall back to credentials.toml — fix the store \
+                 access or unset the entry to make the toml fallback explicit.",
+                account, msg
+            );
+            StoreLookup::BackendError
         }
     }
 }
@@ -178,10 +204,17 @@ impl MdeCredentials {
             .or_else(|| std::env::var("MDE_CLIENT_ID").ok())
             .or(file.client_id);
 
-        let client_secret = std::env::var("MDE_CLIENT_SECRET")
-            .ok()
-            .or_else(|| read_secret_from_store(store, ACCOUNT_CLIENT_SECRET))
-            .or(file.client_secret);
+        let client_secret = std::env::var("MDE_CLIENT_SECRET").ok().or_else(|| {
+            match read_secret_from_store(store, ACCOUNT_CLIENT_SECRET) {
+                StoreLookup::Found(v) => Some(v),
+                // Backend failures: do NOT fall back to plaintext toml.
+                // Surface the missing secret to the caller, which will turn
+                // into a "client_secret not set" error from validate().
+                StoreLookup::BackendError => None,
+                // Store skipped or empty: fall through to toml.
+                StoreLookup::SkipFallthrough | StoreLookup::NotStored => file.client_secret,
+            }
+        });
 
         let access_token = std::env::var("MDE_ACCESS_TOKEN").ok();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,6 +109,11 @@ async fn run(cli: Cli, credentials: MdeCredentials) -> Result<(), AppError> {
         return Ok(());
     }
 
+    // Handle credentials store management (does not require API credentials).
+    if let Commands::Credentials { command: cred_cmd } = &command {
+        return mde::commands::credentials::handle(cred_cmd);
+    }
+
     // Handle agent subcommands.
     if let Commands::Agent { command: agent_cmd } = &command {
         return handle_agent_command(agent_cmd, credentials).await;
@@ -329,6 +334,7 @@ fn requires_agent_routing(command: &Commands) -> bool {
         Commands::Machines { command } => command.is_some(),
         Commands::Auth { command } => command.is_some(),
         Commands::Agent { .. } => false, // agent commands are handled separately
+        Commands::Credentials { .. } => false, // handled locally
         Commands::Completion { .. } => false, // handled locally
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,26 @@ fn main() {
     dotenvy::dotenv().ok();
     let cli = Cli::parse();
 
+    // For subcommands that do not talk to the API (`credentials`,
+    // `completion`), skip resolve() entirely. resolve() may consult the
+    // OS credential store, which can prompt or fail with an ACL error;
+    // letting that noise leak into a `credentials status` invocation
+    // confuses the user — the whole point of `credentials status` is to
+    // tell them about the store, not to be polluted by it.
+    if matches!(
+        cli.command,
+        Some(Commands::Credentials { .. }) | Some(Commands::Completion { .. })
+    ) {
+        let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+        rt.block_on(async {
+            if let Err(e) = run(cli, MdeCredentials::default()).await {
+                eprintln!("Error: {}", e);
+                process::exit(e.exit_code());
+            }
+        });
+        return;
+    }
+
     // Resolve credentials early (before fork).
     let credentials = MdeCredentials::resolve(cli.tenant_id.as_deref(), cli.client_id.as_deref());
 


### PR DESCRIPTION
## What this PR achieves

Replaces plaintext storage of the OAuth2 `client_secret` in `~/.config/mde/credentials.toml` with macOS Keychain–backed storage, eliminating one of the most direct ways the secret can leak (Time Machine backups, dotfile repo accidents, malware reading the home directory under the same uid).

A new `mde-cli credentials` subcommand handles `set` / `delete` / `status` / `migrate`. There is intentionally no `get`: the value never has to leave the Keychain for any legitimate workflow, and exposing one would invite leakage into shell history, terminal scrollback, and AI-agent transcripts.

## Why now

`credentials.toml` is the only place in the project where the long-lived OAuth2 client secret was stored unprotected. `MDE_*` env vars are already scrubbed from the process environment after resolve(), and the agent process intentionally does not propagate the secret to children. Leaving the file as the sole storage tier was the remaining gap.

## How it is implemented

- `src/config/credential_store.rs` introduces a `CredentialStore` trait with a macOS `KeychainStore` (via the `keyring` crate, `apple-native` feature) and a test-only `MemoryStore`. The trait distinguishes `Unavailable` (no backend at all — non-macOS build, CI sandbox without a default keychain) from `Backend` (a real access failure such as a denied prompt).
- `MdeCredentials::resolve()` now consults the store between env vars and the toml. `Unavailable` falls through quietly; `Backend` does **not** fall through to the toml — silently picking up a stale plaintext value would defeat the migration.
- `MdeCredentials`'s `Debug` impl is hand-written to mask `client_secret` and `access_token` (`***`).
- `mde-cli credentials migrate` writes a 0o600 backup, then performs an atomic temp-file + `rename()` rewrite, and rolls back the Keychain entry if the rewrite fails — so the user is never left in an inconsistent half-migrated state. Unsupported quote forms (literal, multi-line) are refused rather than silently mishandled.

## Test plan

- [x] `cargo test --lib` (84 passed)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Manual smoke test: `mde-cli credentials set client-secret` → `status` → real API call
- [x] Manual smoke test: `mde-cli credentials migrate` against a real `credentials.toml`

## Notes for review

- macOS Keychain prompts the user on first access. Users who pin the entry with "Always Allow" see no further prompts unless the binary's signature changes (e.g. after a `cargo install` rebuild). README should mention this — follow-up.
- Linux / Windows backends are intentionally out of scope for this PR; the trait makes them straightforward to add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)