### PR TITLE
release: attach build provenance with actions/attest-build-provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -72,6 +74,11 @@ jobs:
         with:
           path: artifacts
           merge-multiple: true
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: artifacts/*.tar.gz
 
       - name: Create release
         env:


### PR DESCRIPTION
## Summary

- リリースバイナリに SLSA Level 2 相当の build provenance attestation を付与します。
- attestation は Sigstore keyless 署名で生成され、GitHub Attestations API に公開されます。

## Why

リリース成果物の出所（どのリポジトリ・ワークフロー・コミットから作られたか）を暗号的に証明することで、ビルドパイプライン侵害や成果物差し替えを検知できます。SolarWinds 型のビルド侵害や tj-actions/changed-files（CVE-2025-30066）のようなタグ書き換え攻撃の検証基盤になります。

## Changes

- `release` ジョブに `actions/attest-build-provenance@v4.1.0` を追加（SHA 固定）
- 必要最小の permissions を追加
  - `id-token: write` — Sigstore の OIDC トークン取得
  - `attestations: write` — GitHub Attestations API への公開
  - 既存の `contents: write` は維持（`gh release create` 用）

## Consumer side

利用者は `gh attestation verify <file>.tar.gz --repo hiboma/mde-cli` で出所を検証できます。

## References

- [actions/attest-build-provenance](https://github.com/actions/attest-build-provenance)
- [SLSA Level 2 requirements](https://slsa.dev/spec/v1.0/levels#build-l2)
- [GitHub Attestations docs](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)

## Test plan

- [ ] 次回タグ push（`v*`）で release workflow が成功する
- [ ] 生成物に attestation が付与される（Release ページに Build Provenance バッジ、または `gh attestation list --repo hiboma/mde-cli`）
- [ ] `gh attestation verify artifacts/*.tar.gz --repo hiboma/mde-cli` で検証が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)