### PR TITLE
ci: add cargo-deny for advisories, licenses and sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,18 @@ jobs:
           tool: cargo-audit@0.22.1
       - run: cargo audit
 
+  deny:
+    name: Dependency policy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: taiki-e/install-action@eea29cff9a2b68892c0845ae3e4f45fc47ee9354 # v2.75.13
+        with:
+          tool: cargo-deny@0.19.0
+      - run: cargo deny check
+
   actionlint:
     name: Lint workflows
     runs-on: ubuntu-latest

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,42 @@
+# cargo-deny configuration.
+# Docs: https://embarkstudios.github.io/cargo-deny/
+
+[graph]
+all-features = false
+no-default-features = false
+
+[advisories]
+yanked = "deny"
+ignore = []
+
+[licenses]
+# Permissive / weak-copyleft licenses that we accept for this binary.
+# Strong copyleft (GPL, AGPL, LGPL as sole license) is not allowed.
+allow = [
+    "0BSD",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "MIT",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+
+[sources]
+# Only crates.io and (empty) git allowed. This catches PRs that try to
+# slip in a dependency pointing at an unknown registry or git repo.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
## Summary

- `cargo-deny` を CI に追加します。
- `cargo audit`（既存）では拾えない license / source / yanked / wildcard のポリシー違反をゲートにします。

## Why

`cargo audit` は RustSec Advisory Database に基づく既知脆弱性のみを検出します。サプライチェーン攻撃で問題になる他の失敗モードには対応していません。

- **sources**: 悪意ある PR が crates.io 以外のレジストリや git リポジトリを差し込むのを検出（dependency confusion / typosquatting の一部経路）。
- **licenses**: GPL/AGPL 等の単独ライセンスに紛れ込ませるのを検出。互換性の確認不在で依存が混ざるのを防ぎます。
- **yanked**: yanked されたクレートバージョンへの固定をエラーにします。
- **wildcards**: `Cargo.toml` の `*` 指定を禁止し、決定論的な解決を維持します。

## Changes

- `deny.toml` を追加（必要最小のポリシー）。
- `.github/workflows/ci.yml` に `Dependency policy` ジョブを追加（既存の `Security audit` と同じく `taiki-e/install-action` で固定バージョン導入）。
- ローカル実行でも `cargo deny check` が成功することを確認済み。

## References

- [cargo-deny](https://github.com/EmbarkStudios/cargo-deny)
- [OpenSSF Scorecard - Pinned-Dependencies](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)

## Test plan

- [ ] `Dependency policy` ジョブが CI で成功する
- [ ] 意図的に `git = "..."` 依存を入れた PR がジョブで失敗する（動作確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)