### PR TITLE
chore: bump version to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "defender-for-endpoint-cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "arboard",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "defender-for-endpoint-cli"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 description = "CLI tool for Microsoft Defender for Endpoint API"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version from 0.9.0 to 0.10.0
- Minor bump because two new user-facing features shipped since v0.9.0: Keychain-backed credential storage and the MDE Indicators API subcommand

## Changes since v0.9.0
- feat(credentials): back client_secret with macOS Keychain (#52)
- fix(credentials): harden follow-ups from PR #52 (#55)
- feat(indicators): add indicators subcommand for managing MDE indicators (#45)
- ci: add cargo-deny for advisories, licenses and sources (#54)
- release: attach build provenance with actions/attest-build-provenance (#53)
- ci: verify GitHub Actions are pinned with pinact (#49)
- ci: harden workflows and add zizmor static analysis (#50)
- chore(codeowners): require review on security-sensitive paths (#51)

## Test plan
- [ ] CI (check, clippy, fmt, test) passes
- [ ] After merge, push the `v0.10.0` tag and confirm the release workflow builds multi-platform binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)