### PR TITLE
test: serialize env-mutating tests across crates with serial_test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,7 @@ dependencies = [
  "security-framework 3.7.0",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2",
  "subtle",
  "tempfile",
@@ -635,6 +636,17 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-sink"
@@ -1834,10 +1846,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "security-framework"
@@ -1943,6 +1970,32 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,4 +58,5 @@ strip = true
 assert_cmd = "2"
 mockito = "1"
 predicates = "3"
+serial_test = "3"
 tempfile = "3"

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -252,6 +252,7 @@ pub fn validate_credentials(credentials: &crate::config::MdeCredentials) -> Resu
 #[cfg(test)]
 mod env_tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn test_is_env_whitelisted_exact_match() {
@@ -288,6 +289,7 @@ mod env_tests {
     }
 
     #[test]
+    #[serial]
     fn test_sanitize_env_removes_non_whitelisted() {
         let key = "MDE_TEST_SANITIZE_SECRET_12345";
         unsafe {
@@ -304,6 +306,7 @@ mod env_tests {
     }
 
     #[test]
+    #[serial]
     fn test_sanitize_env_keeps_whitelisted() {
         // HOME is whitelisted and typically always set.
         let home_before = std::env::var("HOME").ok();
@@ -315,6 +318,7 @@ mod env_tests {
     }
 
     #[test]
+    #[serial]
     fn test_sanitize_env_removes_mde_credentials() {
         // MDE credentials are no longer whitelisted and should be removed by sanitize_env.
         let key = "MDE_CLIENT_SECRET";

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -336,12 +336,7 @@ unsafe fn overwrite_environ_value(name: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    /// Resolve-related tests mutate process-global env vars (HOME, XDG_CONFIG_HOME,
-    /// MDE_*) which makes them order-dependent under cargo test's default
-    /// thread-pool. Serialize them with a shared mutex.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    use serial_test::serial;
 
     #[test]
     fn test_credentials_file_parse_full() {
@@ -482,8 +477,8 @@ client_secret = "toml-secret"
     }
 
     #[test]
+    #[serial]
     fn test_mde_credentials_resolve_empty() {
-        let _lock = ENV_LOCK.lock().unwrap();
         unsafe { clear_mde_env() };
         with_isolated_credentials(|| {
             let creds = MdeCredentials::resolve(None, None);
@@ -497,8 +492,8 @@ client_secret = "toml-secret"
     }
 
     #[test]
+    #[serial]
     fn test_mde_credentials_clear_env() {
-        let _lock = ENV_LOCK.lock().unwrap();
         // Set MDE env vars
         unsafe {
             std::env::set_var("MDE_TENANT_ID", "test-tenant");
@@ -542,8 +537,8 @@ client_secret = "toml-secret"
     }
 
     #[test]
+    #[serial]
     fn test_mde_credentials_resolve_credentials_file_fallback() {
-        let _lock = ENV_LOCK.lock().unwrap();
         unsafe { clear_mde_env() };
         let toml_content = r#"
 [credentials]
@@ -564,8 +559,8 @@ graph_base_url = "https://custom.graph.example.com"
     }
 
     #[test]
+    #[serial]
     fn test_mde_credentials_resolve_cli_overrides_credentials_file() {
-        let _lock = ENV_LOCK.lock().unwrap();
         unsafe { clear_mde_env() };
         let toml_content = r#"
 [credentials]
@@ -584,8 +579,8 @@ client_secret = "file-secret"
     }
 
     #[test]
+    #[serial]
     fn test_mde_credentials_resolve_then_clear_env() {
-        let _lock = ENV_LOCK.lock().unwrap();
         with_isolated_credentials(|| {
             // Set env vars
             unsafe {
@@ -633,8 +628,8 @@ client_secret = "file-secret"
     }
 
     #[test]
+    #[serial]
     fn test_resolve_with_store_uses_keychain_when_no_env() {
-        let _lock = ENV_LOCK.lock().unwrap();
         unsafe { clear_mde_env() };
         with_isolated_credentials(|| {
             let store = credential_store::test_support::MemoryStore::new();
@@ -645,8 +640,8 @@ client_secret = "file-secret"
     }
 
     #[test]
+    #[serial]
     fn test_resolve_with_store_env_overrides_keychain() {
-        let _lock = ENV_LOCK.lock().unwrap();
         unsafe { clear_mde_env() };
         with_isolated_credentials(|| {
             unsafe { std::env::set_var("MDE_CLIENT_SECRET", "env-secret") };
@@ -659,8 +654,8 @@ client_secret = "file-secret"
     }
 
     #[test]
+    #[serial]
     fn test_resolve_with_store_falls_back_to_toml() {
-        let _lock = ENV_LOCK.lock().unwrap();
         unsafe { clear_mde_env() };
         let toml_content = r#"
 [credentials]


### PR DESCRIPTION
## Summary

- macOS CI で間欠的に失敗していた `config::tests::test_mde_credentials_resolve_credentials_file_fallback` を修正します。
- モジュール横断で env を触るテストを serial 化します。

## Why

既存の `ENV_LOCK: Mutex<()>` は `src/config/mod.rs` のモジュールローカルでした。同一モジュール内の race は防げますが、`src/agent/mod.rs` の `test_sanitize_env_removes_mde_credentials` が別モジュールで `MDE_CLIENT_SECRET` を `set_var` しているため、cargo test のデフォルトスレッドプールで並列実行したときに config 側テストの `resolve()` が別モジュール由来の env 値を拾って assertion に失敗していました。

macOS の CI で再現しやすく、PR #49・#54 でも発生。この flakiness が Ruleset の required status check を通せない要因になっていました。

## Fix

- `serial_test` crate を dev-dep に追加します（プロセス全体で `#[serial]` タグ付きテストを直列実行します）。
- env を触る全テスト（config 8 件、agent 3 件）に `#[serial]` を付与します。
- モジュールローカルの `ENV_LOCK` は不要になるため削除します。

## References

- [serial_test](https://crates.io/crates/serial_test)
- [Rust 1.81 で std::env::set_var が unsafe 化された背景（RFC 3458）](https://github.com/rust-lang/rfcs/blob/master/text/3458-soundness-of-set-env-var.md)

## Test plan

- [ ] `cargo test --locked` がローカル・CI の ubuntu/macos の両方で安定して成功する
- [ ] 10 回 rerun して macOS テストが一度も failure にならない

🤖 Generated with [Claude Code](https://claude.com/claude-code)