### PR TITLE
feat(machines): add add-tag/remove-tag subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1824,9 +1824,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A command-line tool for interacting with the [Microsoft Defender for Endpoint AP
 - **Alerts** - List, get, and update security alerts
 - **Incidents** - List, get, and update incidents (via Microsoft Graph API)
 - **Advanced Hunting** - Run KQL queries against the advanced hunting API
-- **Machines** - List, get machine details, view timelines and logon users
+- **Machines** - List, get machine details, view timelines and logon users, and manage device tags
 - **Indicators** - Create, list, and delete indicators (exclusions/blocks)
 - **Agent Mode** - Credential isolation for use with LLM agents (ssh-agent pattern)
 - **OAuth2 Authentication** - Browser login (Authorization Code Flow with PKCE) and client credentials
@@ -241,6 +241,10 @@ mde-cli machines list
 mde-cli machines get <machine-id>
 mde-cli machines timeline <machine-id>
 mde-cli machines logon-users <machine-id>
+
+# Manage device tags (case-sensitive; remove must use the exact same value)
+mde-cli machines add-tag <machine-id> <tag>
+mde-cli machines remove-tag <machine-id> <tag>
 ```
 
 ### Indicators

--- a/src/cli/machines.rs
+++ b/src/cli/machines.rs
@@ -51,9 +51,9 @@ pub struct LogonUsersArgs {
 
 #[derive(Args)]
 pub struct TagArgs {
-    /// Machine ID
+    /// Machine ID (e.g. 1e5bc9d7e413ddd7902c2932e418702b84d0cc07)
     pub id: String,
 
-    /// Tag value
+    /// Tag value (case-sensitive; remove-tag must be called with the exact same value used to add)
     pub value: String,
 }

--- a/src/cli/machines.rs
+++ b/src/cli/machines.rs
@@ -10,6 +10,10 @@ pub enum MachinesCommand {
     Timeline(TimelineArgs),
     /// Get logon users for a machine
     LogonUsers(LogonUsersArgs),
+    /// Add a tag to a machine
+    AddTag(TagArgs),
+    /// Remove a tag from a machine
+    RemoveTag(TagArgs),
 }
 
 #[derive(Args)]
@@ -43,4 +47,13 @@ pub struct TimelineArgs {
 pub struct LogonUsersArgs {
     /// Machine ID
     pub id: String,
+}
+
+#[derive(Args)]
+pub struct TagArgs {
+    /// Machine ID
+    pub id: String,
+
+    /// Tag value
+    pub value: String,
 }

--- a/src/commands/machines.rs
+++ b/src/commands/machines.rs
@@ -14,6 +14,30 @@ pub async fn handle(
         MachinesCommand::Get(args) => get(client, args, output_format).await,
         MachinesCommand::Timeline(args) => timeline(client, args, output_format, raw).await,
         MachinesCommand::LogonUsers(args) => logon_users(client, args, output_format, raw).await,
+        MachinesCommand::AddTag(args) => update_tag(client, args, "Add", output_format).await,
+        MachinesCommand::RemoveTag(args) => update_tag(client, args, "Remove", output_format).await,
+    }
+}
+
+async fn update_tag(
+    client: &MdeClient,
+    args: &crate::cli::machines::TagArgs,
+    action: &str,
+    output_format: OutputFormat,
+) -> Result<(), AppError> {
+    let path = format!("/api/machines/{}/tags", args.id);
+    let body = serde_json::json!({
+        "Value": args.value,
+        "Action": action,
+    });
+
+    let resp: serde_json::Value = client.post(&path, &body).await?.json().await?;
+
+    match output_format {
+        OutputFormat::Json | OutputFormat::JsonMinify => {
+            crate::output::json::print_json_raw(&resp, output_format.is_minify())
+        }
+        OutputFormat::Table => crate::output::json::print_json_raw(&resp, false),
     }
 }
 

--- a/src/commands/machines.rs
+++ b/src/commands/machines.rs
@@ -25,6 +25,12 @@ async fn update_tag(
     action: &str,
     output_format: OutputFormat,
 ) -> Result<(), AppError> {
+    if args.value.trim().is_empty() {
+        return Err(AppError::InvalidInput(
+            "tag value must not be empty or whitespace-only".to_string(),
+        ));
+    }
+
     let path = format!("/api/machines/{}/tags", args.id);
     let body = serde_json::json!({
         "Value": args.value,


### PR DESCRIPTION
## Motivation

Make MDE device tag management a first-class CLI verb so operators can script it alongside the existing `machines` subcommands instead of calling the REST API by hand.

## Why

MDE uses device tags (e.g. `shared`) as a primary grouping signal for policy scoping, alert triage, and hunting queries. Today every tag change means crafting a raw `POST /api/machines/{id}/tags` with a bearer token — not scriptable, not auditable through the credential isolation agent, and easy to get wrong. Exposing it as `mde-cli machines add-tag` / `remove-tag` lets it flow through the same agent-routed, token-scrubbed path as `list`, `get`, `timeline`, and `logon-users`, and it reuses the existing `machines` whitelist entry so no `agent/security.rs` change is required.

API spec verified against the official docs:
https://learn.microsoft.com/en-us/defender-endpoint/api/add-or-remove-machine-tags

- `POST /api/machines/{id}/tags`
- body: `{"Value": "<tag>", "Action": "Add" | "Remove"}`
- scope: `Machine.ReadWrite(.All)` (already under `securitycenter`, same as other `machines` commands)

## How

- `src/cli/machines.rs`: add `AddTag(TagArgs)` / `RemoveTag(TagArgs)` with shared `TagArgs { id, value }`. Help text includes a Machine ID example and a case-sensitivity note.
- `src/commands/machines.rs`: one shared `update_tag` handler — only the `Action` string differs. Empty / whitespace-only tag values are rejected client-side with `AppError::InvalidInput`. Response (the updated Machine object) is printed as raw JSON.
- `README.md`: update the Features bullet and the Machines usage block.

## Bundled dependency bump

Also included: `chore(deps): bump rustls-webpki to 0.103.13 (RUSTSEC-2026-0104)`. Unrelated to the feature, but CI `Security audit` and `Dependency policy` jobs started failing on main after the advisory was published on 2026-04-22 (reachable panic in CRL parsing via rustls-webpki 0.103.12). Bundling the one-line Cargo.lock bump here unblocks this PR's CI and rolls the patch into main on merge.

## Usage

```
mde-cli machines add-tag    <MACHINE_ID> <TAG_VALUE>
mde-cli machines remove-tag <MACHINE_ID> <TAG_VALUE>
```

## Verification

- `cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`: clean
- `cargo test --lib`: 88 passed
- `machines --help`, `add-tag --help`, `remove-tag --help`: expected output

🤖 Generated with [Claude Code](https://claude.com/claude-code)