### PR TITLE
chore: bump version to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "defender-for-endpoint-cli"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "arboard",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "defender-for-endpoint-cli"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 description = "CLI tool for Microsoft Defender for Endpoint API"
 license = "MIT"


### PR DESCRIPTION
## Motivation

Cut a new minor release so users can install `mde-cli` 0.11.0 with the new device tag commands and the security patch bundled.

## Why

Two changes have landed on main since 0.10.0:

- **feat(machines): `add-tag` / `remove-tag`** (#59) — first-class CLI verbs for the MDE Machine Tags API (`POST /api/machines/{id}/tags`). This is a user-visible new feature on the `machines` resource, which warrants a minor bump per the project's existing cadence (v0.7 → v0.8 → v0.9 → v0.10 each added a feature).
- **chore(deps): rustls-webpki 0.103.13** (bundled in #59) — resolves `RUSTSEC-2026-0104` (reachable panic in CRL parsing). Shipping a release ensures downstream consumers pick up the patched dependency without needing to rebuild from source.

## How

- `Cargo.toml`: `version = "0.10.0"` → `"0.11.0"`
- `Cargo.lock`: regenerated via `cargo update -p defender-for-endpoint-cli`

After this merges, a `v0.11.0` tag will be pushed to trigger the `release.yml` workflow (multi-arch binaries + CycloneDX SBOM + build provenance attestation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)