### PR TITLE
chore: bump version to 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "defender-for-endpoint-cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "arboard",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "defender-for-endpoint-cli"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 description = "CLI tool for Microsoft Defender for Endpoint API"
 license = "MIT"


### PR DESCRIPTION
## 概要

バージョンを 0.11.0 から 0.12.0 に上げます(minor version up)。

## 背景

直近で dependabot の依存更新を 9 件マージしました。主な変更点は以下です。

- tokio 1.50.0 → 1.51.1、rand 0.9.4 → 0.10.0(`Rng` → `RngExt` 移行)、rpassword 7.4.0 → 7.5.4(macOS ビルド破壊の回避)、uuid/toml/libc のパッチ更新
- GitHub Actions: codeql-action v4.36.0、taiki-e/install-action v2.81.1、actions/upload-artifact v7.0.1

これらの依存更新を区切るため minor を上げます。

## 変更

- `Cargo.toml` / `Cargo.lock` の version を 0.12.0 に更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)