### PR TITLE
ci(release): build static musl binaries to fix glibc incompatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,9 @@ jobs:
         if: contains(matrix.target, 'linux-musl')
         with:
           version: 0.13.0
+          # Disable caching: release builds must not consume runtime caches
+          # that a less-trusted workflow could poison (supply-chain hardening).
+          use-cache: false
       - uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
         if: contains(matrix.target, 'linux-musl')
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - target: x86_64-unknown-linux-gnu
+          # Statically linked musl builds: no glibc dependency, so they run on
+          # any Linux regardless of the host glibc version (e.g. Ubuntu 22.04).
+          - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             artifact: mde-cli
-          - target: aarch64-unknown-linux-gnu
+          - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
             artifact: mde-cli
           - target: x86_64-apple-darwin
@@ -37,14 +39,19 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.target }}
 
-      - name: Install cross-compilation tools
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+      # cargo-zigbuild links musl targets via zig as the C toolchain, so both
+      # x86_64 and aarch64 cross-compile without installing per-target gcc.
+      - uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
+        if: contains(matrix.target, 'linux-musl')
+        with:
+          tool: cargo-zigbuild@0.22.1
+
+      - name: Build (musl via zigbuild)
+        if: contains(matrix.target, 'linux-musl')
+        run: cargo zigbuild --release --locked --target ${{ matrix.target }}
 
       - name: Build
+        if: ${{ !contains(matrix.target, 'linux-musl') }}
         run: cargo build --release --locked --target ${{ matrix.target }}
 
       - name: Package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,11 @@ jobs:
 
       # cargo-zigbuild links musl targets via zig as the C toolchain, so both
       # x86_64 and aarch64 cross-compile without installing per-target gcc.
+      # cargo-zigbuild does NOT bundle zig, so zig must be installed separately.
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        if: contains(matrix.target, 'linux-musl')
+        with:
+          version: 0.13.0
       - uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
         if: contains(matrix.target, 'linux-musl')
         with:


### PR DESCRIPTION
## 目的

Linux 向けリリースバイナリの GLIBC 互換問題を根本解決します。

## 背景

ビルド済みの `mde-cli` を Ubuntu 22.04 (GLIBC 2.35) で実行すると次のエラーで起動できませんでした。

```
./mde-cli: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by ./mde-cli)
```

`release.yml` が `ubuntu-latest` (現在は Ubuntu 24.04, GLIBC 2.39) で動的リンクビルドしていたため、より古い GLIBC の環境で動かない状態でした。GLIBC は後方互換のみで前方互換がないため、新しい GLIBC でビルドしたバイナリは古い環境で動きません。

## 変更内容

- Linux ターゲットを `*-unknown-linux-gnu` から `*-unknown-linux-musl` に変更
- ビルドを `cargo zigbuild` に置き換え (`taiki-e/install-action` で `cargo-zigbuild@0.22.1` を導入)
- musl 静的リンクにより GLIBC 非依存となり、Ubuntu 22.04 を含むほぼ全ての Linux で動作
- zig が aarch64 のクロスコンパイルも担うため、`gcc-aarch64-linux-gnu` の導入手順を削除
- Apple ターゲットは従来どおり `cargo build`

`reqwest` を `rustls-tls` (OpenSSL 非依存) で使っているため、musl 静的リンクへの移行はシステムライブラリ依存を増やしません。

## 検証

- 手元で `cargo zigbuild --release --target x86_64-unknown-linux-musl` が成功
- 生成物が `statically linked` であることを `file` コマンドで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)