### PR TITLE
chore: bump version to 0.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "defender-for-endpoint-cli"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "arboard",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "defender-for-endpoint-cli"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 description = "CLI tool for Microsoft Defender for Endpoint API"
 license = "MIT"


### PR DESCRIPTION
## 目的

GLIBC 互換問題を解決する musl 静的リンクビルド (#75) をリリースするため、バージョンを 0.12.1 に上げます。

## 変更内容

- `Cargo.toml` / `Cargo.lock` のバージョンを 0.12.0 から 0.12.1 に更新

## 補足

このタグ push により release ワークフローが走り、4 ターゲット (x86_64/aarch64 の linux-musl、x86_64/aarch64 の apple-darwin) のバイナリがビルドされます。Linux バイナリは musl 静的リンクとなり GLIBC 非依存です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)