### PR TITLE
feat(auth): save browser login tokens to macOS Keychain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1595,9 +1595,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/README.md
+++ b/README.md
@@ -200,9 +200,6 @@ remove or replace the allowed-applications list.
 # Browser login (Authorization Code Flow with PKCE)
 mde-cli auth login
 
-# Show token for client_credentials flow (CI use)
-mde-cli auth token
-
 # Client credentials (non-interactive)
 export MDE_TENANT_ID="your-tenant-id"
 export MDE_CLIENT_ID="your-client-id"

--- a/src/auth/browser.rs
+++ b/src/auth/browser.rs
@@ -248,6 +248,53 @@ pub async fn browser_login(
     exchange_code(tenant_id, client_id, &code, &verifier, scope).await
 }
 
+pub async fn refresh_access_token(
+    tenant_id: &str,
+    client_id: &str,
+    refresh_token: &str,
+    scope: &str,
+) -> Result<BrowserLoginResult, AppError> {
+    let token_url = format!(
+        "https://login.microsoftonline.com/{}/oauth2/v2.0/token",
+        tenant_id
+    );
+
+    let params = [
+        ("grant_type", "refresh_token"),
+        ("client_id", client_id),
+        ("refresh_token", refresh_token),
+        ("scope", scope),
+    ];
+
+    let http = reqwest::Client::new();
+    let resp = http
+        .post(&token_url)
+        .form(&params)
+        .send()
+        .await
+        .map_err(|e| AppError::Auth(format!("token refresh failed: {}", e)))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(AppError::Auth(format!(
+            "token refresh returned {}: {}",
+            status, body
+        )));
+    }
+
+    let token_resp: TokenResponse = resp
+        .json()
+        .await
+        .map_err(|e| AppError::Auth(format!("failed to parse refresh response: {}", e)))?;
+
+    Ok(BrowserLoginResult {
+        access_token: token_resp.access_token,
+        expires_in: token_resp.expires_in,
+        refresh_token: token_resp.refresh_token,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/auth/browser.rs
+++ b/src/auth/browser.rs
@@ -169,16 +169,22 @@ fn wait_for_auth_code(
 struct TokenResponse {
     access_token: String,
     expires_in: u64,
+    refresh_token: Option<String>,
 }
 
-/// Exchange the authorization code for an access token.
+pub struct BrowserLoginResult {
+    pub access_token: String,
+    pub expires_in: u64,
+    pub refresh_token: Option<String>,
+}
+
 async fn exchange_code(
     tenant_id: &str,
     client_id: &str,
     code: &str,
     verifier: &str,
     scope: &str,
-) -> Result<(String, u64), AppError> {
+) -> Result<BrowserLoginResult, AppError> {
     let redirect_uri = format!("http://localhost:{}{}", REDIRECT_PORT, REDIRECT_PATH);
     let token_url = format!(
         "https://login.microsoftonline.com/{}/oauth2/v2.0/token",
@@ -216,7 +222,11 @@ async fn exchange_code(
         .await
         .map_err(|e| AppError::Auth(format!("failed to parse token response: {}", e)))?;
 
-    Ok((token_resp.access_token, token_resp.expires_in))
+    Ok(BrowserLoginResult {
+        access_token: token_resp.access_token,
+        expires_in: token_resp.expires_in,
+        refresh_token: token_resp.refresh_token,
+    })
 }
 
 /// Run the full browser-based OAuth2 authorization code flow with PKCE.
@@ -224,7 +234,7 @@ pub async fn browser_login(
     tenant_id: &str,
     client_id: &str,
     scope: &str,
-) -> Result<(String, u64), AppError> {
+) -> Result<BrowserLoginResult, AppError> {
     let (code, verifier) = tokio::task::spawn_blocking({
         let tenant_id = tenant_id.to_string();
         let client_id = client_id.to_string();

--- a/src/auth/browser.rs
+++ b/src/auth/browser.rs
@@ -178,6 +178,45 @@ pub struct BrowserLoginResult {
     pub refresh_token: Option<String>,
 }
 
+async fn post_token_request(
+    tenant_id: &str,
+    params: &[(&str, &str)],
+    operation: &str,
+) -> Result<BrowserLoginResult, AppError> {
+    let token_url = format!(
+        "https://login.microsoftonline.com/{}/oauth2/v2.0/token",
+        tenant_id
+    );
+
+    let http = reqwest::Client::new();
+    let resp = http
+        .post(&token_url)
+        .form(&params)
+        .send()
+        .await
+        .map_err(|e| AppError::Auth(format!("{} failed: {}", operation, e)))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(AppError::Auth(format!(
+            "{} returned {}: {}",
+            operation, status, body
+        )));
+    }
+
+    let token_resp: TokenResponse = resp
+        .json()
+        .await
+        .map_err(|e| AppError::Auth(format!("failed to parse {} response: {}", operation, e)))?;
+
+    Ok(BrowserLoginResult {
+        access_token: token_resp.access_token,
+        expires_in: token_resp.expires_in,
+        refresh_token: token_resp.refresh_token,
+    })
+}
+
 async fn exchange_code(
     tenant_id: &str,
     client_id: &str,
@@ -186,11 +225,6 @@ async fn exchange_code(
     scope: &str,
 ) -> Result<BrowserLoginResult, AppError> {
     let redirect_uri = format!("http://localhost:{}{}", REDIRECT_PORT, REDIRECT_PATH);
-    let token_url = format!(
-        "https://login.microsoftonline.com/{}/oauth2/v2.0/token",
-        tenant_id
-    );
-
     let params = [
         ("grant_type", "authorization_code"),
         ("client_id", client_id),
@@ -199,34 +233,7 @@ async fn exchange_code(
         ("code_verifier", verifier),
         ("scope", scope),
     ];
-
-    let http = reqwest::Client::new();
-    let resp = http
-        .post(&token_url)
-        .form(&params)
-        .send()
-        .await
-        .map_err(|e| AppError::Auth(format!("token exchange failed: {}", e)))?;
-
-    let status = resp.status();
-    if !status.is_success() {
-        let body = resp.text().await.unwrap_or_default();
-        return Err(AppError::Auth(format!(
-            "token exchange returned {}: {}",
-            status, body
-        )));
-    }
-
-    let token_resp: TokenResponse = resp
-        .json()
-        .await
-        .map_err(|e| AppError::Auth(format!("failed to parse token response: {}", e)))?;
-
-    Ok(BrowserLoginResult {
-        access_token: token_resp.access_token,
-        expires_in: token_resp.expires_in,
-        refresh_token: token_resp.refresh_token,
-    })
+    post_token_request(tenant_id, &params, "token exchange").await
 }
 
 /// Run the full browser-based OAuth2 authorization code flow with PKCE.
@@ -254,45 +261,13 @@ pub async fn refresh_access_token(
     refresh_token: &str,
     scope: &str,
 ) -> Result<BrowserLoginResult, AppError> {
-    let token_url = format!(
-        "https://login.microsoftonline.com/{}/oauth2/v2.0/token",
-        tenant_id
-    );
-
     let params = [
         ("grant_type", "refresh_token"),
         ("client_id", client_id),
         ("refresh_token", refresh_token),
         ("scope", scope),
     ];
-
-    let http = reqwest::Client::new();
-    let resp = http
-        .post(&token_url)
-        .form(&params)
-        .send()
-        .await
-        .map_err(|e| AppError::Auth(format!("token refresh failed: {}", e)))?;
-
-    let status = resp.status();
-    if !status.is_success() {
-        let body = resp.text().await.unwrap_or_default();
-        return Err(AppError::Auth(format!(
-            "token refresh returned {}: {}",
-            status, body
-        )));
-    }
-
-    let token_resp: TokenResponse = resp
-        .json()
-        .await
-        .map_err(|e| AppError::Auth(format!("failed to parse refresh response: {}", e)))?;
-
-    Ok(BrowserLoginResult {
-        access_token: token_resp.access_token,
-        expires_in: token_resp.expires_in,
-        refresh_token: token_resp.refresh_token,
-    })
+    post_token_request(tenant_id, &params, "token refresh").await
 }
 
 #[cfg(test)]

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -4,6 +4,4 @@ use clap::Subcommand;
 pub enum AuthCommand {
     /// Login via browser (Authorization Code Flow with PKCE)
     Login,
-    /// Show token for the client_credentials flow (CI use)
-    Token,
 }

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -14,11 +14,9 @@ pub async fn handle(
     command: &AuthCommand,
     tenant_id: &str,
     client_id: &str,
-    client_secret: Option<&str>,
 ) -> Result<(), AppError> {
     match command {
         AuthCommand::Login => login(tenant_id, client_id).await,
-        AuthCommand::Token => token(tenant_id, client_id, client_secret).await,
     }
 }
 
@@ -67,36 +65,6 @@ async fn login(tenant_id: &str, client_id: &str) -> Result<(), AppError> {
         clipboard::copy_and_verify(&result.access_token, result.expires_in)?;
     } else {
         clipboard::print_token(&result.access_token);
-    }
-
-    Ok(())
-}
-
-async fn token(
-    tenant_id: &str,
-    client_id: &str,
-    client_secret: Option<&str>,
-) -> Result<(), AppError> {
-    let secret = client_secret.ok_or_else(|| {
-        AppError::Auth(
-            "client_secret is required for token command. Set MDE_CLIENT_SECRET.".to_string(),
-        )
-    })?;
-
-    let auth = crate::auth::oauth2::OAuth2Auth::new(
-        tenant_id.to_string(),
-        client_id.to_string(),
-        secret.to_string(),
-        "https://api.securitycenter.microsoft.com/.default".to_string(),
-    )?;
-
-    let token = auth.fetch_token().await?;
-
-    if clipboard::is_tty() {
-        eprintln!("Token acquired via client_credentials flow.");
-        clipboard::print_token(&token);
-    } else {
-        clipboard::print_token(&token);
     }
 
     Ok(())

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -26,7 +26,10 @@ fn compute_expires_at(expires_in: u64) -> u64 {
     now + expires_in
 }
 
-pub fn save_tokens_to_keychain(result: &browser::BrowserLoginResult) -> Result<bool, AppError> {
+pub fn save_tokens_to_keychain(
+    result: &browser::BrowserLoginResult,
+    existing_refresh_token: Option<&str>,
+) -> Result<bool, AppError> {
     let Some(store) = default_store() else {
         return Ok(false);
     };
@@ -34,7 +37,10 @@ pub fn save_tokens_to_keychain(result: &browser::BrowserLoginResult) -> Result<b
     let bundle = TokenBundle {
         access_token: result.access_token.clone(),
         expires_at: compute_expires_at(result.expires_in),
-        refresh_token: result.refresh_token.clone(),
+        refresh_token: result
+            .refresh_token
+            .clone()
+            .or_else(|| existing_refresh_token.map(|s| s.to_string())),
     };
 
     let json = serde_json::to_string(&bundle)
@@ -55,7 +61,7 @@ pub fn save_tokens_to_keychain(result: &browser::BrowserLoginResult) -> Result<b
 async fn login(tenant_id: &str, client_id: &str) -> Result<(), AppError> {
     let result = browser::browser_login(tenant_id, client_id, MDE_SCOPE).await?;
 
-    let saved = save_tokens_to_keychain(&result)?;
+    let saved = save_tokens_to_keychain(&result, None)?;
     if !saved {
         if clipboard::is_tty() {
             clipboard::copy_and_verify(&result.access_token, result.expires_in)?;

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -3,9 +3,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::auth::browser;
 use crate::auth::clipboard;
 use crate::cli::auth::AuthCommand;
-use crate::config::credential_store::{
-    KEY_ACCESS_TOKEN, KEY_REFRESH_TOKEN, KEY_TOKEN_EXPIRES_AT, default_store,
-};
+use crate::config::credential_store::{KEY_TOKEN_BUNDLE, TokenBundle, default_store};
 use crate::error::AppError;
 
 pub const MDE_SCOPE: &str = "https://api.securitycenter.microsoft.com/.default offline_access";
@@ -20,51 +18,50 @@ pub async fn handle(
     }
 }
 
-fn compute_expires_at(expires_in: u64) -> String {
+fn compute_expires_at(expires_in: u64) -> u64 {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
-    (now + expires_in).to_string()
+    now + expires_in
 }
 
-pub fn save_tokens_to_keychain(result: &browser::BrowserLoginResult) -> Result<(), AppError> {
+pub fn save_tokens_to_keychain(result: &browser::BrowserLoginResult) -> Result<bool, AppError> {
     let Some(store) = default_store() else {
-        return Ok(());
+        return Ok(false);
     };
 
-    store
-        .set(KEY_ACCESS_TOKEN, &result.access_token)
-        .map_err(|e| AppError::Auth(format!("failed to save access token: {}", e)))?;
+    let bundle = TokenBundle {
+        access_token: result.access_token.clone(),
+        expires_at: compute_expires_at(result.expires_in),
+        refresh_token: result.refresh_token.clone(),
+    };
 
-    let expires_at = compute_expires_at(result.expires_in);
+    let json = serde_json::to_string(&bundle)
+        .map_err(|e| AppError::Auth(format!("failed to serialize token bundle: {}", e)))?;
+
     store
-        .set(KEY_TOKEN_EXPIRES_AT, &expires_at)
-        .map_err(|e| AppError::Auth(format!("failed to save token expiry: {}", e)))?;
+        .set(KEY_TOKEN_BUNDLE, &json)
+        .map_err(|e| AppError::Auth(format!("failed to save token bundle: {}", e)))?;
+
     eprintln!(
-        "Access token saved to keychain. (expires in {}s)",
+        "Token bundle saved to keychain. (expires in {}s)",
         result.expires_in
     );
 
-    if let Some(ref rt) = result.refresh_token {
-        store
-            .set(KEY_REFRESH_TOKEN, rt)
-            .map_err(|e| AppError::Auth(format!("failed to save refresh token: {}", e)))?;
-        eprintln!("Refresh token saved to keychain.");
-    }
-
-    Ok(())
+    Ok(true)
 }
 
 async fn login(tenant_id: &str, client_id: &str) -> Result<(), AppError> {
     let result = browser::browser_login(tenant_id, client_id, MDE_SCOPE).await?;
 
-    if default_store().is_some() {
-        save_tokens_to_keychain(&result)?;
-    } else if clipboard::is_tty() {
-        clipboard::copy_and_verify(&result.access_token, result.expires_in)?;
-    } else {
-        clipboard::print_token(&result.access_token);
+    let saved = save_tokens_to_keychain(&result)?;
+    if !saved {
+        if clipboard::is_tty() {
+            clipboard::copy_and_verify(&result.access_token, result.expires_in)?;
+        } else {
+            clipboard::print_token(&result.access_token);
+        }
     }
 
     Ok(())

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -8,7 +8,7 @@ use crate::config::credential_store::{
 };
 use crate::error::AppError;
 
-const MDE_SCOPE: &str = "https://api.securitycenter.microsoft.com/.default offline_access";
+pub const MDE_SCOPE: &str = "https://api.securitycenter.microsoft.com/.default offline_access";
 
 pub async fn handle(
     command: &AuthCommand,

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -1,7 +1,11 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use crate::auth::browser;
 use crate::auth::clipboard;
 use crate::cli::auth::AuthCommand;
-use crate::config::credential_store::{KEY_ACCESS_TOKEN, KEY_REFRESH_TOKEN, default_store};
+use crate::config::credential_store::{
+    KEY_ACCESS_TOKEN, KEY_REFRESH_TOKEN, KEY_TOKEN_EXPIRES_AT, default_store,
+};
 use crate::error::AppError;
 
 const MDE_SCOPE: &str = "https://api.securitycenter.microsoft.com/.default offline_access";
@@ -18,24 +22,47 @@ pub async fn handle(
     }
 }
 
+fn compute_expires_at(expires_in: u64) -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    (now + expires_in).to_string()
+}
+
+pub fn save_tokens_to_keychain(result: &browser::BrowserLoginResult) -> Result<(), AppError> {
+    let Some(store) = default_store() else {
+        return Ok(());
+    };
+
+    store
+        .set(KEY_ACCESS_TOKEN, &result.access_token)
+        .map_err(|e| AppError::Auth(format!("failed to save access token: {}", e)))?;
+
+    let expires_at = compute_expires_at(result.expires_in);
+    store
+        .set(KEY_TOKEN_EXPIRES_AT, &expires_at)
+        .map_err(|e| AppError::Auth(format!("failed to save token expiry: {}", e)))?;
+    eprintln!(
+        "Access token saved to keychain. (expires in {}s)",
+        result.expires_in
+    );
+
+    if let Some(ref rt) = result.refresh_token {
+        store
+            .set(KEY_REFRESH_TOKEN, rt)
+            .map_err(|e| AppError::Auth(format!("failed to save refresh token: {}", e)))?;
+        eprintln!("Refresh token saved to keychain.");
+    }
+
+    Ok(())
+}
+
 async fn login(tenant_id: &str, client_id: &str) -> Result<(), AppError> {
     let result = browser::browser_login(tenant_id, client_id, MDE_SCOPE).await?;
 
-    if let Some(store) = default_store() {
-        store
-            .set(KEY_ACCESS_TOKEN, &result.access_token)
-            .map_err(|e| AppError::Auth(format!("failed to save access token: {}", e)))?;
-        eprintln!(
-            "Access token saved to keychain. (expires in {}s)",
-            result.expires_in
-        );
-
-        if let Some(ref rt) = result.refresh_token {
-            store
-                .set(KEY_REFRESH_TOKEN, rt)
-                .map_err(|e| AppError::Auth(format!("failed to save refresh token: {}", e)))?;
-            eprintln!("Refresh token saved to keychain.");
-        }
+    if default_store().is_some() {
+        save_tokens_to_keychain(&result)?;
     } else if clipboard::is_tty() {
         clipboard::copy_and_verify(&result.access_token, result.expires_in)?;
     } else {

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -1,6 +1,7 @@
 use crate::auth::browser;
 use crate::auth::clipboard;
 use crate::cli::auth::AuthCommand;
+use crate::config::credential_store::{KEY_ACCESS_TOKEN, KEY_REFRESH_TOKEN, default_store};
 use crate::error::AppError;
 
 const MDE_SCOPE: &str = "https://api.securitycenter.microsoft.com/.default offline_access";
@@ -18,12 +19,27 @@ pub async fn handle(
 }
 
 async fn login(tenant_id: &str, client_id: &str) -> Result<(), AppError> {
-    let (token, expires_in) = browser::browser_login(tenant_id, client_id, MDE_SCOPE).await?;
+    let result = browser::browser_login(tenant_id, client_id, MDE_SCOPE).await?;
 
-    if clipboard::is_tty() {
-        clipboard::copy_and_verify(&token, expires_in)?;
+    if let Some(store) = default_store() {
+        store
+            .set(KEY_ACCESS_TOKEN, &result.access_token)
+            .map_err(|e| AppError::Auth(format!("failed to save access token: {}", e)))?;
+        eprintln!(
+            "Access token saved to keychain. (expires in {}s)",
+            result.expires_in
+        );
+
+        if let Some(ref rt) = result.refresh_token {
+            store
+                .set(KEY_REFRESH_TOKEN, rt)
+                .map_err(|e| AppError::Auth(format!("failed to save refresh token: {}", e)))?;
+            eprintln!("Refresh token saved to keychain.");
+        }
+    } else if clipboard::is_tty() {
+        clipboard::copy_and_verify(&result.access_token, result.expires_in)?;
     } else {
-        clipboard::print_token(&token);
+        clipboard::print_token(&result.access_token);
     }
 
     Ok(())

--- a/src/config/credential_store.rs
+++ b/src/config/credential_store.rs
@@ -4,10 +4,9 @@ use std::fmt;
 /// Acts as a namespace so credentials do not collide with other apps.
 pub const SERVICE: &str = "dev.mde-cli";
 
-/// Logical identifier for the OAuth2 client_secret entry. This is the
-/// label / key used to look the entry up in the store; it is NOT the
-/// secret value itself.
 pub const KEY_CLIENT_SECRET: &str = "client_secret";
+pub const KEY_ACCESS_TOKEN: &str = "access_token";
+pub const KEY_REFRESH_TOKEN: &str = "refresh_token";
 
 #[derive(Debug)]
 pub enum StoreError {

--- a/src/config/credential_store.rs
+++ b/src/config/credential_store.rs
@@ -7,11 +7,28 @@ pub const SERVICE: &str = "dev.mde-cli";
 pub const KEY_CLIENT_SECRET: &str = "client_secret";
 pub const KEY_TOKEN_BUNDLE: &str = "token_bundle";
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Clone)]
 pub struct TokenBundle {
     pub access_token: String,
     pub expires_at: u64,
     pub refresh_token: Option<String>,
+}
+
+impl fmt::Debug for TokenBundle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TokenBundle")
+            .field("access_token", &"***")
+            .field("expires_at", &self.expires_at)
+            .field(
+                "refresh_token",
+                if self.refresh_token.is_some() {
+                    &"***"
+                } else {
+                    &"None"
+                },
+            )
+            .finish()
+    }
 }
 
 #[derive(Debug)]

--- a/src/config/credential_store.rs
+++ b/src/config/credential_store.rs
@@ -5,9 +5,14 @@ use std::fmt;
 pub const SERVICE: &str = "dev.mde-cli";
 
 pub const KEY_CLIENT_SECRET: &str = "client_secret";
-pub const KEY_ACCESS_TOKEN: &str = "access_token";
-pub const KEY_REFRESH_TOKEN: &str = "refresh_token";
-pub const KEY_TOKEN_EXPIRES_AT: &str = "token_expires_at";
+pub const KEY_TOKEN_BUNDLE: &str = "token_bundle";
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+pub struct TokenBundle {
+    pub access_token: String,
+    pub expires_at: u64,
+    pub refresh_token: Option<String>,
+}
 
 #[derive(Debug)]
 pub enum StoreError {

--- a/src/config/credential_store.rs
+++ b/src/config/credential_store.rs
@@ -7,6 +7,7 @@ pub const SERVICE: &str = "dev.mde-cli";
 pub const KEY_CLIENT_SECRET: &str = "client_secret";
 pub const KEY_ACCESS_TOKEN: &str = "access_token";
 pub const KEY_REFRESH_TOKEN: &str = "refresh_token";
+pub const KEY_TOKEN_EXPIRES_AT: &str = "token_expires_at";
 
 #[derive(Debug)]
 pub enum StoreError {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -654,6 +654,7 @@ client_secret = "file-secret"
             client_id: Some("c".into()),
             client_secret: Some("super-secret".into()),
             access_token: Some("super-token".into()),
+            refresh_token: Some("super-refresh".into()),
             ..Default::default()
         };
         let dbg = format!("{:?}", creds);
@@ -663,6 +664,11 @@ client_secret = "file-secret"
             dbg
         );
         assert!(!dbg.contains("super-token"), "access_token leaked: {}", dbg);
+        assert!(
+            !dbg.contains("super-refresh"),
+            "refresh_token leaked: {}",
+            dbg
+        );
         assert!(dbg.contains("***"));
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,8 +6,7 @@ use serde::Deserialize;
 pub mod credential_store;
 
 use credential_store::{
-    CredentialStore, KEY_ACCESS_TOKEN, KEY_CLIENT_SECRET, KEY_REFRESH_TOKEN, KEY_TOKEN_EXPIRES_AT,
-    StoreError, default_store,
+    CredentialStore, KEY_CLIENT_SECRET, KEY_TOKEN_BUNDLE, StoreError, TokenBundle, default_store,
 };
 
 const DEFAULT_MDE_BASE_URL: &str = "https://api.security.microsoft.com";
@@ -51,18 +50,19 @@ enum StoreLookup {
     BackendError,
 }
 
-fn is_token_expired(store: Option<&dyn CredentialStore>) -> bool {
-    match read_secret_from_store(store, KEY_TOKEN_EXPIRES_AT) {
-        StoreLookup::Found(v) => {
-            let expires_at: u64 = v.parse().unwrap_or(0);
-            let now = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs();
-            now >= expires_at
-        }
-        _ => true,
+fn resolve_token_bundle(store: Option<&dyn CredentialStore>) -> Option<TokenBundle> {
+    match read_secret_from_store(store, KEY_TOKEN_BUNDLE) {
+        StoreLookup::Found(v) => serde_json::from_str(&v).ok(),
+        _ => None,
     }
+}
+
+fn is_bundle_expired(bundle: &TokenBundle) -> bool {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    now >= bundle.expires_at
 }
 
 fn read_secret_from_store(store: Option<&dyn CredentialStore>, key: &str) -> StoreLookup {
@@ -235,25 +235,19 @@ impl MdeCredentials {
             }
         });
 
+        let bundle = resolve_token_bundle(store);
+
         let access_token = std::env::var("MDE_ACCESS_TOKEN").ok().or_else(|| {
-            match read_secret_from_store(store, KEY_ACCESS_TOKEN) {
-                StoreLookup::Found(v) => {
-                    if is_token_expired(store) {
-                        None
-                    } else {
-                        Some(v)
-                    }
+            bundle.as_ref().and_then(|b| {
+                if is_bundle_expired(b) {
+                    None
+                } else {
+                    Some(b.access_token.clone())
                 }
-                StoreLookup::BackendError
-                | StoreLookup::SkipFallthrough
-                | StoreLookup::NotStored => None,
-            }
+            })
         });
 
-        let refresh_token = match read_secret_from_store(store, KEY_REFRESH_TOKEN) {
-            StoreLookup::Found(v) => Some(v),
-            _ => None,
-        };
+        let refresh_token = bundle.as_ref().and_then(|b| b.refresh_token.clone());
 
         let mde_base_url = file
             .mde_base_url
@@ -714,20 +708,37 @@ client_secret = "toml-secret"
         });
     }
 
-    fn future_expires_at() -> String {
+    fn future_expires_at() -> u64 {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_secs();
-        (now + 3600).to_string()
+        now + 3600
     }
 
-    fn past_expires_at() -> String {
+    fn past_expires_at() -> u64 {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_secs();
-        (now.saturating_sub(60)).to_string()
+        now.saturating_sub(60)
+    }
+
+    fn store_token_bundle(
+        store: &credential_store::test_support::MemoryStore,
+        access_token: &str,
+        expires_at: u64,
+        refresh_token: Option<&str>,
+    ) {
+        let bundle = credential_store::TokenBundle {
+            access_token: access_token.to_string(),
+            expires_at,
+            refresh_token: refresh_token.map(String::from),
+        };
+        let json = serde_json::to_string(&bundle).unwrap();
+        store
+            .set(credential_store::KEY_TOKEN_BUNDLE, &json)
+            .unwrap();
     }
 
     #[test]
@@ -736,12 +747,7 @@ client_secret = "toml-secret"
         unsafe { clear_mde_env() };
         with_isolated_credentials(|| {
             let store = credential_store::test_support::MemoryStore::new();
-            store
-                .set(credential_store::KEY_ACCESS_TOKEN, "kc-token")
-                .unwrap();
-            store
-                .set(credential_store::KEY_TOKEN_EXPIRES_AT, &future_expires_at())
-                .unwrap();
+            store_token_bundle(&store, "kc-token", future_expires_at(), None);
             let creds = MdeCredentials::resolve_with_store(None, None, Some(&store));
             assert_eq!(creds.access_token.as_deref(), Some("kc-token"));
         });
@@ -753,12 +759,7 @@ client_secret = "toml-secret"
         unsafe { clear_mde_env() };
         with_isolated_credentials(|| {
             let store = credential_store::test_support::MemoryStore::new();
-            store
-                .set(credential_store::KEY_ACCESS_TOKEN, "expired-token")
-                .unwrap();
-            store
-                .set(credential_store::KEY_TOKEN_EXPIRES_AT, &past_expires_at())
-                .unwrap();
+            store_token_bundle(&store, "expired-token", past_expires_at(), None);
             let creds = MdeCredentials::resolve_with_store(None, None, Some(&store));
             assert!(creds.access_token.is_none());
         });
@@ -771,9 +772,7 @@ client_secret = "toml-secret"
         with_isolated_credentials(|| {
             unsafe { std::env::set_var("MDE_ACCESS_TOKEN", "env-token") };
             let store = credential_store::test_support::MemoryStore::new();
-            store
-                .set(credential_store::KEY_ACCESS_TOKEN, "kc-token")
-                .unwrap();
+            store_token_bundle(&store, "kc-token", future_expires_at(), None);
             let creds = MdeCredentials::resolve_with_store(None, None, Some(&store));
             assert_eq!(creds.access_token.as_deref(), Some("env-token"));
             unsafe { std::env::remove_var("MDE_ACCESS_TOKEN") };
@@ -797,11 +796,22 @@ client_secret = "toml-secret"
         unsafe { clear_mde_env() };
         with_isolated_credentials(|| {
             let store = credential_store::test_support::MemoryStore::new();
-            store
-                .set(credential_store::KEY_REFRESH_TOKEN, "kc-refresh")
-                .unwrap();
+            store_token_bundle(&store, "kc-token", future_expires_at(), Some("kc-refresh"));
             let creds = MdeCredentials::resolve_with_store(None, None, Some(&store));
             assert_eq!(creds.refresh_token.as_deref(), Some("kc-refresh"));
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_expired_bundle_still_returns_refresh_token() {
+        unsafe { clear_mde_env() };
+        with_isolated_credentials(|| {
+            let store = credential_store::test_support::MemoryStore::new();
+            store_token_bundle(&store, "expired-token", past_expires_at(), Some("rt"));
+            let creds = MdeCredentials::resolve_with_store(None, None, Some(&store));
+            assert!(creds.access_token.is_none());
+            assert_eq!(creds.refresh_token.as_deref(), Some("rt"));
         });
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5,7 +5,9 @@ use serde::Deserialize;
 
 pub mod credential_store;
 
-use credential_store::{CredentialStore, KEY_CLIENT_SECRET, StoreError, default_store};
+use credential_store::{
+    CredentialStore, KEY_ACCESS_TOKEN, KEY_CLIENT_SECRET, StoreError, default_store,
+};
 
 const DEFAULT_MDE_BASE_URL: &str = "https://api.security.microsoft.com";
 const DEFAULT_GRAPH_BASE_URL: &str = "https://graph.microsoft.com";
@@ -215,7 +217,12 @@ impl MdeCredentials {
             }
         });
 
-        let access_token = std::env::var("MDE_ACCESS_TOKEN").ok();
+        let access_token = std::env::var("MDE_ACCESS_TOKEN").ok().or_else(|| {
+            match read_secret_from_store(store, KEY_ACCESS_TOKEN) {
+                StoreLookup::Found(v) => Some(v),
+                _ => None,
+            }
+        });
 
         let mde_base_url = file
             .mde_base_url

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -220,7 +220,9 @@ impl MdeCredentials {
         let access_token = std::env::var("MDE_ACCESS_TOKEN").ok().or_else(|| {
             match read_secret_from_store(store, KEY_ACCESS_TOKEN) {
                 StoreLookup::Found(v) => Some(v),
-                _ => None,
+                StoreLookup::BackendError
+                | StoreLookup::SkipFallthrough
+                | StoreLookup::NotStored => None,
             }
         });
 
@@ -673,6 +675,47 @@ client_secret = "toml-secret"
             // Keychain empty -> falls through to TOML.
             let creds = MdeCredentials::resolve_with_store(None, None, Some(&store));
             assert_eq!(creds.client_secret.as_deref(), Some("toml-secret"));
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_access_token_from_keychain() {
+        unsafe { clear_mde_env() };
+        with_isolated_credentials(|| {
+            let store = credential_store::test_support::MemoryStore::new();
+            store
+                .set(credential_store::KEY_ACCESS_TOKEN, "kc-token")
+                .unwrap();
+            let creds = MdeCredentials::resolve_with_store(None, None, Some(&store));
+            assert_eq!(creds.access_token.as_deref(), Some("kc-token"));
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_access_token_env_overrides_keychain() {
+        unsafe { clear_mde_env() };
+        with_isolated_credentials(|| {
+            unsafe { std::env::set_var("MDE_ACCESS_TOKEN", "env-token") };
+            let store = credential_store::test_support::MemoryStore::new();
+            store
+                .set(credential_store::KEY_ACCESS_TOKEN, "kc-token")
+                .unwrap();
+            let creds = MdeCredentials::resolve_with_store(None, None, Some(&store));
+            assert_eq!(creds.access_token.as_deref(), Some("env-token"));
+            unsafe { std::env::remove_var("MDE_ACCESS_TOKEN") };
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_access_token_none_when_keychain_empty() {
+        unsafe { clear_mde_env() };
+        with_isolated_credentials(|| {
+            let store = credential_store::test_support::MemoryStore::new();
+            let creds = MdeCredentials::resolve_with_store(None, None, Some(&store));
+            assert!(creds.access_token.is_none());
         });
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,7 +6,8 @@ use serde::Deserialize;
 pub mod credential_store;
 
 use credential_store::{
-    CredentialStore, KEY_ACCESS_TOKEN, KEY_CLIENT_SECRET, StoreError, default_store,
+    CredentialStore, KEY_ACCESS_TOKEN, KEY_CLIENT_SECRET, KEY_REFRESH_TOKEN, KEY_TOKEN_EXPIRES_AT,
+    StoreError, default_store,
 };
 
 const DEFAULT_MDE_BASE_URL: &str = "https://api.security.microsoft.com";
@@ -48,6 +49,20 @@ enum StoreLookup {
     /// up a stale plaintext secret would defeat the point of moving the
     /// secret into the Keychain in the first place.
     BackendError,
+}
+
+fn is_token_expired(store: Option<&dyn CredentialStore>) -> bool {
+    match read_secret_from_store(store, KEY_TOKEN_EXPIRES_AT) {
+        StoreLookup::Found(v) => {
+            let expires_at: u64 = v.parse().unwrap_or(0);
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            now >= expires_at
+        }
+        _ => true,
+    }
 }
 
 fn read_secret_from_store(store: Option<&dyn CredentialStore>, key: &str) -> StoreLookup {
@@ -131,6 +146,7 @@ pub struct MdeCredentials {
     pub client_id: Option<String>,
     pub client_secret: Option<String>,
     pub access_token: Option<String>,
+    pub refresh_token: Option<String>,
     pub mde_base_url: String,
     pub graph_base_url: String,
 }
@@ -145,6 +161,7 @@ impl std::fmt::Debug for MdeCredentials {
             .field("client_id", &self.client_id)
             .field("client_secret", &mask(&self.client_secret))
             .field("access_token", &mask(&self.access_token))
+            .field("refresh_token", &mask(&self.refresh_token))
             .field("mde_base_url", &self.mde_base_url)
             .field("graph_base_url", &self.graph_base_url)
             .finish()
@@ -165,6 +182,7 @@ impl Default for MdeCredentials {
             client_id: None,
             client_secret: None,
             access_token: None,
+            refresh_token: None,
             mde_base_url: DEFAULT_MDE_BASE_URL.to_string(),
             graph_base_url: DEFAULT_GRAPH_BASE_URL.to_string(),
         }
@@ -219,12 +237,23 @@ impl MdeCredentials {
 
         let access_token = std::env::var("MDE_ACCESS_TOKEN").ok().or_else(|| {
             match read_secret_from_store(store, KEY_ACCESS_TOKEN) {
-                StoreLookup::Found(v) => Some(v),
+                StoreLookup::Found(v) => {
+                    if is_token_expired(store) {
+                        None
+                    } else {
+                        Some(v)
+                    }
+                }
                 StoreLookup::BackendError
                 | StoreLookup::SkipFallthrough
                 | StoreLookup::NotStored => None,
             }
         });
+
+        let refresh_token = match read_secret_from_store(store, KEY_REFRESH_TOKEN) {
+            StoreLookup::Found(v) => Some(v),
+            _ => None,
+        };
 
         let mde_base_url = file
             .mde_base_url
@@ -239,6 +268,7 @@ impl MdeCredentials {
             client_id,
             client_secret,
             access_token,
+            refresh_token,
             mde_base_url,
             graph_base_url,
         }
@@ -678,6 +708,22 @@ client_secret = "toml-secret"
         });
     }
 
+    fn future_expires_at() -> String {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        (now + 3600).to_string()
+    }
+
+    fn past_expires_at() -> String {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        (now.saturating_sub(60)).to_string()
+    }
+
     #[test]
     #[serial]
     fn test_resolve_access_token_from_keychain() {
@@ -687,8 +733,28 @@ client_secret = "toml-secret"
             store
                 .set(credential_store::KEY_ACCESS_TOKEN, "kc-token")
                 .unwrap();
+            store
+                .set(credential_store::KEY_TOKEN_EXPIRES_AT, &future_expires_at())
+                .unwrap();
             let creds = MdeCredentials::resolve_with_store(None, None, Some(&store));
             assert_eq!(creds.access_token.as_deref(), Some("kc-token"));
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_access_token_expired_returns_none() {
+        unsafe { clear_mde_env() };
+        with_isolated_credentials(|| {
+            let store = credential_store::test_support::MemoryStore::new();
+            store
+                .set(credential_store::KEY_ACCESS_TOKEN, "expired-token")
+                .unwrap();
+            store
+                .set(credential_store::KEY_TOKEN_EXPIRES_AT, &past_expires_at())
+                .unwrap();
+            let creds = MdeCredentials::resolve_with_store(None, None, Some(&store));
+            assert!(creds.access_token.is_none());
         });
     }
 
@@ -716,6 +782,20 @@ client_secret = "toml-secret"
             let store = credential_store::test_support::MemoryStore::new();
             let creds = MdeCredentials::resolve_with_store(None, None, Some(&store));
             assert!(creds.access_token.is_none());
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_refresh_token_from_keychain() {
+        unsafe { clear_mde_env() };
+        with_isolated_credentials(|| {
+            let store = credential_store::test_support::MemoryStore::new();
+            store
+                .set(credential_store::KEY_REFRESH_TOKEN, "kc-refresh")
+                .unwrap();
+            let creds = MdeCredentials::resolve_with_store(None, None, Some(&store));
+            assert_eq!(creds.refresh_token.as_deref(), Some("kc-refresh"));
         });
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -53,7 +53,8 @@ enum StoreLookup {
 fn resolve_token_bundle(store: Option<&dyn CredentialStore>) -> Option<TokenBundle> {
     match read_secret_from_store(store, KEY_TOKEN_BUNDLE) {
         StoreLookup::Found(v) => serde_json::from_str(&v).ok(),
-        _ => None,
+        StoreLookup::BackendError => None,
+        StoreLookup::SkipFallthrough | StoreLookup::NotStored => None,
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -270,10 +270,12 @@ async fn run(cli: Cli, mut credentials: MdeCredentials) -> Result<(), AppError> 
             }
             Err(e) => {
                 eprintln!("warning: token refresh failed: {}", e);
-                return Err(AppError::Auth(
-                    "Authentication expired. Run `mde-cli auth login` to re-authenticate."
-                        .to_string(),
-                ));
+                if credentials.client_secret.is_none() {
+                    return Err(AppError::Auth(
+                        "Authentication expired. Run `mde-cli auth login` to re-authenticate."
+                            .to_string(),
+                    ));
+                }
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -250,7 +250,10 @@ async fn run(cli: Cli, mut credentials: MdeCredentials) -> Result<(), AppError> 
                     "Access token refreshed. (expires in {}s)",
                     result.expires_in
                 );
-                match mde::commands::auth::save_tokens_to_keychain(&result) {
+                match mde::commands::auth::save_tokens_to_keychain(
+                    &result,
+                    credentials.refresh_token.as_deref(),
+                ) {
                     Ok(false) => {
                         eprintln!(
                             "warning: no credential store available. \
@@ -265,7 +268,8 @@ async fn run(cli: Cli, mut credentials: MdeCredentials) -> Result<(), AppError> 
                     }
                     Ok(true) => {}
                 }
-                credentials.refresh_token = result.refresh_token;
+                credentials.refresh_token =
+                    result.refresh_token.or(credentials.refresh_token.take());
                 credentials.access_token = Some(result.access_token);
             }
             Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -230,13 +230,7 @@ async fn run(cli: Cli, mut credentials: MdeCredentials) -> Result<(), AppError> 
         let cid = credentials.client_id.as_deref().ok_or_else(|| {
             AppError::Config("client_id not set. Use --client-id or MDE_CLIENT_ID.".to_string())
         })?;
-        return mde::commands::auth::handle(
-            auth_cmd,
-            tid,
-            cid,
-            credentials.client_secret.as_deref(),
-        )
-        .await;
+        return mde::commands::auth::handle(auth_cmd, tid, cid).await;
     }
 
     // If the keychain access token is expired but a refresh token is available,

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,7 +167,7 @@ fn main() {
     });
 }
 
-async fn run(cli: Cli, credentials: MdeCredentials) -> Result<(), AppError> {
+async fn run(cli: Cli, mut credentials: MdeCredentials) -> Result<(), AppError> {
     let command = match cli.command {
         Some(command) => command,
         None => {
@@ -237,6 +237,41 @@ async fn run(cli: Cli, credentials: MdeCredentials) -> Result<(), AppError> {
             credentials.client_secret.as_deref(),
         )
         .await;
+    }
+
+    // If the keychain access token is expired but a refresh token is available,
+    // try to refresh before building the API client.
+    if credentials.access_token.is_none()
+        && let (Some(tid), Some(cid), Some(rt)) = (
+            &credentials.tenant_id,
+            &credentials.client_id,
+            &credentials.refresh_token,
+        )
+    {
+        match mde::auth::browser::refresh_access_token(
+            tid,
+            cid,
+            rt,
+            "https://api.securitycenter.microsoft.com/.default offline_access",
+        )
+        .await
+        {
+            Ok(result) => {
+                eprintln!(
+                    "Access token refreshed. (expires in {}s)",
+                    result.expires_in
+                );
+                credentials.access_token = Some(result.access_token.clone());
+                if let Some(ref new_rt) = result.refresh_token {
+                    credentials.refresh_token = Some(new_rt.clone());
+                }
+                let _ = mde::commands::auth::save_tokens_to_keychain(&result);
+            }
+            Err(e) => {
+                eprintln!("warning: token refresh failed: {}", e);
+                eprintln!("Run `mde-cli auth login` to re-authenticate.");
+            }
+        }
     }
 
     // For API commands, build client with appropriate auth

--- a/src/main.rs
+++ b/src/main.rs
@@ -250,20 +250,30 @@ async fn run(cli: Cli, mut credentials: MdeCredentials) -> Result<(), AppError> 
                     "Access token refreshed. (expires in {}s)",
                     result.expires_in
                 );
-                credentials.access_token = Some(result.access_token.clone());
-                if let Some(ref new_rt) = result.refresh_token {
-                    credentials.refresh_token = Some(new_rt.clone());
+                match mde::commands::auth::save_tokens_to_keychain(&result) {
+                    Ok(false) => {
+                        eprintln!(
+                            "warning: no credential store available. \
+                             Refreshed token is valid for this session only."
+                        );
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "warning: failed to save refreshed tokens to keychain: {}",
+                            e
+                        );
+                    }
+                    Ok(true) => {}
                 }
-                if let Err(e) = mde::commands::auth::save_tokens_to_keychain(&result) {
-                    eprintln!(
-                        "warning: failed to save refreshed tokens to keychain: {}",
-                        e
-                    );
-                }
+                credentials.refresh_token = result.refresh_token;
+                credentials.access_token = Some(result.access_token);
             }
             Err(e) => {
                 eprintln!("warning: token refresh failed: {}", e);
-                eprintln!("Run `mde-cli auth login` to re-authenticate.");
+                return Err(AppError::Auth(
+                    "Authentication expired. Run `mde-cli auth login` to re-authenticate."
+                        .to_string(),
+                ));
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -242,13 +242,8 @@ async fn run(cli: Cli, mut credentials: MdeCredentials) -> Result<(), AppError> 
             &credentials.refresh_token,
         )
     {
-        match mde::auth::browser::refresh_access_token(
-            tid,
-            cid,
-            rt,
-            "https://api.securitycenter.microsoft.com/.default offline_access",
-        )
-        .await
+        match mde::auth::browser::refresh_access_token(tid, cid, rt, mde::commands::auth::MDE_SCOPE)
+            .await
         {
             Ok(result) => {
                 eprintln!(
@@ -259,7 +254,12 @@ async fn run(cli: Cli, mut credentials: MdeCredentials) -> Result<(), AppError> 
                 if let Some(ref new_rt) = result.refresh_token {
                     credentials.refresh_token = Some(new_rt.clone());
                 }
-                let _ = mde::commands::auth::save_tokens_to_keychain(&result);
+                if let Err(e) = mde::commands::auth::save_tokens_to_keychain(&result) {
+                    eprintln!(
+                        "warning: failed to save refreshed tokens to keychain: {}",
+                        e
+                    );
+                }
             }
             Err(e) => {
                 eprintln!("warning: token refresh failed: {}", e);


### PR DESCRIPTION
## Summary

- `mde-cli auth login` で取得したアクセストークンとリフレッシュトークンを macOS Keychain に自動保存し、以降のコマンドで自動利用できるようにする
- トークンの有効期限を管理し、期限切れ時は refresh_token で自動更新する
- `auth token` サブコマンドを削除し、トークン漏洩リスクを排除する

## Why

従来の `mde-cli auth login` はトークンをクリップボードにコピーするだけで、Keychain には保存していなかった。ユーザーは login のたびにトークンを手動で環境変数に設定する必要があり、UX が悪かった。また `auth token` サブコマンドはトークンを stdout に出力するため漏洩リスクがあった。

## Changes

### Token lifecycle

```
login → Keychain に TokenBundle (JSON) として一括保存
  ↓
API コマンド実行時
  ├─ 有効期限内 → TokenBundle の access_token を使用
  ├─ 期限切れ + refresh_token あり → 自動リフレッシュ → Keychain 再保存
  ├─ リフレッシュ失敗 + client_secret あり → client_credentials フローにフォールバック
  └─ リフレッシュ失敗 + client_secret なし → 再 login を案内してエラー終了
```

### Token resolution priority

`MDE_ACCESS_TOKEN` env > Keychain TokenBundle (with expiry check) > (none: falls through to client_credentials flow)

### Implementation

- `browser_login` の戻り値を `BrowserLoginResult` 構造体に変更し `refresh_token` を含める
- トークン関連の3つの Keychain エントリ (`access_token`, `refresh_token`, `token_expires_at`) を `TokenBundle` として1つの JSON エントリに統合
  - Keychain ロック解除が1回で済む（従来は3回）
  - 書き込みの atomicity 問題を解消
- `TokenBundle` の Debug impl でトークン値をマスクし漏洩を防止
- `post_token_request` ヘルパーを抽出し `exchange_code` / `refresh_access_token` の重複を排除
- `save_tokens_to_keychain` が `Result<bool>` を返し、credential store 非対応環境を明示的に通知
- `MdeCredentials::resolve` で `TokenBundle` から access_token (有効期限チェック付き) と refresh_token を解決
- API コマンド実行前にトークンリフレッシュを自動試行し、成功時は Keychain に再保存
- `auth token` サブコマンドを削除（トークン漏洩防止）

## Test plan

- [x] `cargo test` — ユニットテスト全件通過 (94 tests)
- [x] `cargo clippy` — 指摘なし
- [x] `cargo fmt` — フォーマット済み
- [ ] `mde-cli auth login` で Keychain にトークンが保存されることを確認
- [ ] login 後に `mde-cli machines list` 等で Keychain のトークンが自動利用されることを確認
- [ ] トークン期限切れ後に refresh_token で自動更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)