### PR TITLE
chore: bump version to 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "defender-for-endpoint-cli"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "arboard",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "defender-for-endpoint-cli"
-version = "0.12.1"
+version = "0.13.0"
 edition = "2024"
 description = "CLI tool for Microsoft Defender for Endpoint API"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump version from 0.12.1 to 0.13.0 for the Keychain TokenBundle release

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>