### PR TITLE
feat: add doctor diagnostic subcommand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,23 @@ cargo fmt                # Format
 - Uses `securitycenter` scope, same as alerts/machines
 - Registered in agent command whitelist (`agent/security.rs`)
 
+### Doctor
+
+- `doctor` subcommand prints a one-screen diagnostic: CONFIG (which
+  credentials.toml is in effect), ACTIVE CREDENTIALS (each field's
+  effective value and its source), ENVIRONMENT (MDE_* set/unset), and
+  CONNECTIVITY (a `GET /api/machines?$top=1` probe with elapsed time)
+- Never prints secret values: `client_secret`/`access_token`/`refresh_token`
+  show presence + source only; `client_id` is masked to its first 4 chars;
+  secret-bearing env vars show `(set, hidden)`
+- Provenance comes from `MdeCredentials::resolve_with_provenance` in
+  `config/mod.rs`, which mirrors `resolve` but records a `Source` per field.
+  `resolve_with_store` delegates to it and drops the metadata
+- Handled locally before the env scrub in `main.rs` (alongside
+  `credentials`/`completion`); does not route through the agent. It does not
+  forward `--tenant-id`/`--client-id` because clap merges those flags with
+  their env vars, which would misattribute the source
+
 ### Shared Mode
 
 - `mde-cli agent start --shared` writes session info to `~/.local/share/mde-cli/session.json`

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A command-line tool for interacting with the [Microsoft Defender for Endpoint AP
 - **Indicators** - Create, list, and delete indicators (exclusions/blocks)
 - **Agent Mode** - Credential isolation for use with LLM agents (ssh-agent pattern)
 - **OAuth2 Authentication** - Browser login (Authorization Code Flow with PKCE) and client credentials
+- **Doctor** - Diagnose configuration, credential provenance, environment, and connectivity
 
 ## Installation
 
@@ -193,6 +194,60 @@ remove or replace the allowed-applications list.
 3. Create a client secret under **Certificates & secrets**
 
 ## Usage
+
+### Diagnostics (`doctor`)
+
+`mde-cli doctor` prints a one-screen diagnostic of your setup: which
+config file is in effect, the effective credentials and **where each one
+resolved from**, the state of the `MDE_*` environment variables, and a
+live connectivity probe. Run it first whenever something is not working.
+
+```bash
+mde-cli doctor
+```
+
+```text
+mde-cli 0.13.0
+
+CONFIG
+  path:    /Users/you/.config/mde/credentials.toml
+  status:  present
+
+ACTIVE CREDENTIALS
+  tenant-id:      11111111-2222-3333-...       (source: env MDE_TENANT_ID)
+  client-id:      abcd****                     (source: credentials.toml)
+  client-secret:  present                      (source: keychain dev.mde-cli/client_secret)
+  access-token:   present (expires in 42m)     (source: keychain dev.mde-cli/token_bundle)
+  refresh-token:  present                      (source: keychain dev.mde-cli/token_bundle)
+  mde-base-url:   https://api.security.microsoft.com
+  graph-base-url: https://graph.microsoft.com
+
+ENVIRONMENT
+  MDE_TENANT_ID          (set)
+  MDE_CLIENT_ID          (set)
+  MDE_CLIENT_SECRET      (set, hidden)
+  ...
+
+CONNECTIVITY
+  GET https://api.security.microsoft.com/api/machines?$top=1  ->  200 OK (243ms)
+```
+
+Security notes:
+
+- `doctor` **never prints a secret value.** `client_secret`,
+  `access_token`, and `refresh_token` are reported by presence and source
+  only. `client_id` is masked to its first four characters.
+- Secret-bearing environment variables (`MDE_CLIENT_SECRET`,
+  `MDE_ACCESS_TOKEN`, `MDE_AGENT_TOKEN`) are shown as `(set, hidden)` /
+  `(unset)` — never their value.
+- The connectivity probe sends the bearer token in the request but only
+  the HTTP status and elapsed time are printed. A `401`/`403` still
+  confirms the service was reached. The probe is `skipped` when no
+  credentials are available to build a client.
+
+> On macOS, `doctor` reads the Keychain to report token/secret
+> presence, so the standard Keychain access prompt may appear (see
+> [Notes on Keychain prompts](#notes-on-keychain-prompts)).
 
 ### Authentication
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -37,6 +37,7 @@ Authentication:
   credentials        Manage stored credentials (Keychain on macOS)
 
 Other:
+  doctor             Diagnose configuration, credentials, and connectivity
   completion         Generate shell completion script
   help               Print this message or the help of the given subcommand(s)
 
@@ -172,6 +173,9 @@ pub enum Commands {
         #[command(subcommand)]
         command: credentials::CredentialsCommand,
     },
+    /// Diagnose configuration, credentials, environment, and connectivity
+    #[command(hide = true)]
+    Doctor,
     /// Generate shell completion script
     #[command(hide = true)]
     Completion {
@@ -191,6 +195,7 @@ impl Commands {
             Commands::Indicators { .. } => "indicators",
             Commands::Agent { .. } => "agent",
             Commands::Credentials { .. } => "credentials",
+            Commands::Doctor => "doctor",
             Commands::Completion { .. } => "completion",
         }
     }

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -1,0 +1,458 @@
+//! `doctor` — diagnose configuration, credentials, environment, and
+//! connectivity in a single screen.
+//!
+//! Security: this command never prints a secret value. `client_secret`,
+//! `access_token`, and `refresh_token` are reported only by presence and
+//! source. `client_id` is shown masked to its first few characters. The
+//! point of `doctor` is to tell the user *where* each value comes from and
+//! *whether* it resolved — not what it is.
+
+use std::path::PathBuf;
+use std::time::Instant;
+
+use crate::auth::StaticTokenAuth;
+use crate::auth::oauth2::OAuth2Auth;
+use crate::client::MdeClient;
+use crate::config::credential_store::default_store;
+use crate::config::{CredentialProvenance, MdeCredentials, Resolved, Source};
+use crate::error::AppError;
+
+/// Scope used for the connectivity probe (same as alerts/machines).
+const SECURITYCENTER_SCOPE: &str = "https://api.securitycenter.microsoft.com/.default";
+/// Lightweight endpoint for the connectivity probe.
+const PROBE_PATH: &str = "/api/machines?$top=1";
+
+/// Number of leading characters of `client_id` to reveal. The client ID is
+/// an app identifier (not a secret), but it pins down which tenant/app this
+/// install talks to, so we still avoid printing it in full to logs and
+/// screenshots.
+const CLIENT_ID_VISIBLE_PREFIX: usize = 4;
+
+pub async fn handle() -> Result<(), AppError> {
+    let version = env!("CARGO_PKG_VERSION");
+    println!("mde-cli {}", version);
+    println!();
+
+    print_config_section();
+
+    // Resolve with no CLI args: clap merges `--tenant-id` and the
+    // `MDE_TENANT_ID` env var into one field, so forwarding it would
+    // misattribute env-supplied values as CLI args. Reading env/toml here
+    // gives doctor an accurate provenance.
+    let store = default_store();
+    let prov = MdeCredentials::resolve_with_provenance(None, None, store.as_deref());
+
+    print_credentials_section(&prov);
+    print_environment_section();
+    print_connectivity_section(&prov).await;
+
+    Ok(())
+}
+
+/// CONFIG: which credentials.toml (if any) is in effect.
+fn print_config_section() {
+    println!("CONFIG");
+    match find_credentials_toml() {
+        Some(path) => {
+            let display = std::fs::canonicalize(&path).unwrap_or(path);
+            println!("  path:    {}", display.display());
+            println!("  status:  present");
+        }
+        None => {
+            // Show the paths we looked at so the user knows where to put one.
+            println!("  path:    (none found)");
+            println!("  status:  absent");
+            println!("  searched:");
+            for p in credentials_search_paths() {
+                println!("    {}", p.display());
+            }
+        }
+    }
+    println!();
+}
+
+/// ACTIVE CREDENTIALS: the effective value of each field and where it came
+/// from. Secrets are never printed; `client_id` is masked.
+fn print_credentials_section(prov: &CredentialProvenance) {
+    println!("ACTIVE CREDENTIALS");
+
+    // tenant_id is not a secret (it appears in URLs); print it in full.
+    print_field(
+        "tenant-id",
+        &describe_plain(&prov.tenant_id),
+        &prov.tenant_id.source,
+    );
+
+    // client_id: reveal only the leading prefix.
+    let client_id_desc = match &prov.client_id.value {
+        Some(v) => mask_prefix(v),
+        None => "(not set)".to_string(),
+    };
+    print_field("client-id", &client_id_desc, &prov.client_id.source);
+
+    // client_secret: presence only.
+    print_field(
+        "client-secret",
+        &describe_secret(&prov.client_secret),
+        &prov.client_secret.source,
+    );
+
+    // access_token: presence + remaining lifetime when known.
+    print_field(
+        "access-token",
+        &describe_access_token(prov),
+        &prov.access_token.source,
+    );
+
+    // refresh_token: presence only.
+    print_field(
+        "refresh-token",
+        &describe_secret(&prov.refresh_token),
+        &prov.refresh_token.source,
+    );
+
+    println!("  mde-base-url:   {}", prov.mde_base_url);
+    println!("  graph-base-url: {}", prov.graph_base_url);
+    println!();
+}
+
+/// Print one credential field line: `label: value (source: ...)`.
+/// The source suffix is omitted when nothing resolved.
+fn print_field(label: &str, value: &str, source: &Source) {
+    if *source == Source::None {
+        println!("  {:<15} {}", format!("{}:", label), value);
+    } else {
+        println!(
+            "  {:<15} {:<28} (source: {})",
+            format!("{}:", label),
+            value,
+            source.label()
+        );
+    }
+}
+
+/// Plain (non-secret) value description: print it, or `(not set)`.
+fn describe_plain(r: &Resolved<String>) -> String {
+    match &r.value {
+        Some(v) => v.clone(),
+        None => "(not set)".to_string(),
+    }
+}
+
+/// Secret presence description: never the value.
+fn describe_secret(r: &Resolved<String>) -> String {
+    match &r.value {
+        Some(_) => "present".to_string(),
+        None => "(not set)".to_string(),
+    }
+}
+
+/// access_token presence + remaining lifetime when the expiry is known
+/// (i.e. it came from a Keychain TokenBundle). Env-supplied tokens have
+/// unknown expiry. An expired bundle resolves to no value but we still
+/// surface that it was found-but-expired.
+fn describe_access_token(prov: &CredentialProvenance) -> String {
+    match &prov.access_token.value {
+        Some(_) => match prov.access_token_expires_at {
+            Some(exp) => format!("present ({})", format_remaining(exp)),
+            None => "present (expiry unknown)".to_string(),
+        },
+        None => match prov.access_token_expires_at {
+            // We had a bundle but it was expired.
+            Some(_) => "expired".to_string(),
+            None => "(not set)".to_string(),
+        },
+    }
+}
+
+/// Mask a client ID to its leading prefix, e.g. `1234****`.
+fn mask_prefix(s: &str) -> String {
+    let prefix: String = s.chars().take(CLIENT_ID_VISIBLE_PREFIX).collect();
+    format!("{}****", prefix)
+}
+
+/// Format the remaining lifetime of a Unix-epoch expiry as `expires in 42m`
+/// or `expired`.
+fn format_remaining(expires_at: u64) -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    if expires_at <= now {
+        return "expired".to_string();
+    }
+    let secs = expires_at - now;
+    if secs >= 3600 {
+        format!("expires in {}h{}m", secs / 3600, (secs % 3600) / 60)
+    } else if secs >= 60 {
+        format!("expires in {}m", secs / 60)
+    } else {
+        format!("expires in {}s", secs)
+    }
+}
+
+/// ENVIRONMENT: which MDE_* variables are set. Values are never printed;
+/// for the two secret-bearing variables we say `set (hidden)` to make clear
+/// the value exists but is intentionally not shown.
+fn print_environment_section() {
+    println!("ENVIRONMENT");
+    // (name, is_secret)
+    let vars = [
+        ("MDE_TENANT_ID", false),
+        ("MDE_CLIENT_ID", false),
+        ("MDE_CLIENT_SECRET", true),
+        ("MDE_ACCESS_TOKEN", true),
+        ("MDE_OUTPUT_FORMAT", false),
+        ("MDE_AGENT_SOCKET", false),
+        ("MDE_AGENT_TOKEN", true),
+    ];
+    for (name, is_secret) in vars {
+        let state = match std::env::var(name) {
+            Ok(_) if is_secret => "(set, hidden)",
+            Ok(_) => "(set)",
+            Err(_) => "(unset)",
+        };
+        println!("  {:<22} {}", name, state);
+    }
+    println!();
+}
+
+/// CONNECTIVITY: probe a lightweight API endpoint. Skipped when there are
+/// no credentials to build a client with. The probe sends the bearer token
+/// in the request, but the token value is never logged; only the HTTP
+/// status and elapsed time are shown.
+async fn print_connectivity_section(prov: &CredentialProvenance) {
+    println!("CONNECTIVITY");
+
+    let client = match build_probe_client(prov) {
+        Ok(c) => c,
+        Err(reason) => {
+            println!("  GET {}{}", prov.mde_base_url, PROBE_PATH);
+            println!("    skipped ({})", reason);
+            return;
+        }
+    };
+
+    let url = format!("{}{}", prov.mde_base_url, PROBE_PATH);
+    let start = Instant::now();
+    let result = client.get(PROBE_PATH).await;
+    let elapsed = start.elapsed().as_millis();
+
+    match result {
+        Ok(resp) => {
+            let status = resp.status();
+            println!("  GET {}  ->  {} ({}ms)", url, status, elapsed);
+        }
+        Err(AppError::Api { status, .. }) => {
+            // A 401/403 still proves we reached the service.
+            println!("  GET {}  ->  {} ({}ms)", url, status, elapsed);
+        }
+        Err(e) => {
+            println!(
+                "  GET {}  ->  error: {} ({}ms)",
+                url,
+                summarize_error(&e.to_string()),
+                elapsed
+            );
+        }
+    }
+}
+
+/// Collapse a verbose error string into a single line for the diagnostic
+/// view. Token-endpoint failures embed a large JSON body; we surface just
+/// the leading message plus any Azure AD `AADSTS#####` code, which is the
+/// part a user actually needs to act on. The full error is still available
+/// by running the failing command directly.
+fn summarize_error(msg: &str) -> String {
+    // First non-empty line, with surrounding whitespace trimmed.
+    let first_line = msg
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .unwrap_or("")
+        .to_string();
+
+    // Pull out an AADSTS error code if present anywhere in the message.
+    let aadsts = msg
+        .split(|c: char| !(c.is_ascii_alphanumeric()))
+        .find(|tok| tok.starts_with("AADSTS"));
+
+    // Truncate the leading line so a JSON blob on one physical line cannot
+    // blow up the output.
+    const MAX: usize = 120;
+    let mut head = if first_line.chars().count() > MAX {
+        let truncated: String = first_line.chars().take(MAX).collect();
+        format!("{}…", truncated)
+    } else {
+        first_line
+    };
+
+    if let Some(code) = aadsts
+        && !head.contains(code)
+    {
+        head = format!("{} [{}]", head, code);
+    }
+    head
+}
+
+/// Build a client for the connectivity probe using the same auth precedence
+/// as the real API path: a static access token if present, otherwise
+/// OAuth2 client-credentials. Returns a short reason string when there is
+/// nothing to build with, so the caller can render `skipped (reason)`.
+fn build_probe_client(prov: &CredentialProvenance) -> Result<MdeClient, String> {
+    if let Some(token) = &prov.access_token.value {
+        let auth = StaticTokenAuth(token.clone());
+        return MdeClient::new(prov.mde_base_url.clone(), Box::new(auth))
+            .map_err(|e| e.to_string());
+    }
+
+    let (tid, cid, cs) = match (
+        &prov.tenant_id.value,
+        &prov.client_id.value,
+        &prov.client_secret.value,
+    ) {
+        (Some(t), Some(c), Some(s)) => (t, c, s),
+        _ => return Err("no credentials".to_string()),
+    };
+
+    let auth = OAuth2Auth::new(
+        tid.clone(),
+        cid.clone(),
+        cs.clone(),
+        SECURITYCENTER_SCOPE.to_string(),
+    )
+    .map_err(|e| e.to_string())?;
+    MdeClient::new(prov.mde_base_url.clone(), Box::new(auth)).map_err(|e| e.to_string())
+}
+
+/// Search paths for credentials.toml, mirroring `config`'s own order.
+/// Kept local so `doctor` can show the searched paths without exposing
+/// `config`'s internal helper.
+fn credentials_search_paths() -> Vec<PathBuf> {
+    let mut paths = vec![PathBuf::from(".mde-credentials.toml")];
+    if let Ok(config_home) = std::env::var("XDG_CONFIG_HOME") {
+        paths.push(
+            PathBuf::from(config_home)
+                .join("mde")
+                .join("credentials.toml"),
+        );
+    } else if let Ok(home) = std::env::var("HOME") {
+        paths.push(
+            PathBuf::from(home)
+                .join(".config")
+                .join("mde")
+                .join("credentials.toml"),
+        );
+    }
+    paths
+}
+
+fn find_credentials_toml() -> Option<PathBuf> {
+    credentials_search_paths().into_iter().find(|p| p.is_file())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mask_prefix_reveals_only_leading_chars() {
+        assert_eq!(mask_prefix("12345678-90ab"), "1234****");
+        assert_eq!(mask_prefix("ab"), "ab****");
+        assert_eq!(mask_prefix(""), "****");
+    }
+
+    #[test]
+    fn describe_secret_never_returns_value() {
+        let present = Resolved {
+            value: Some("super-secret".to_string()),
+            source: Source::Env("MDE_CLIENT_SECRET"),
+        };
+        let desc = describe_secret(&present);
+        assert_eq!(desc, "present");
+        assert!(!desc.contains("super-secret"));
+
+        let absent: Resolved<String> = Resolved {
+            value: None,
+            source: Source::None,
+        };
+        assert_eq!(describe_secret(&absent), "(not set)");
+    }
+
+    #[test]
+    fn format_remaining_buckets() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        assert_eq!(format_remaining(now.saturating_sub(10)), "expired");
+        assert!(format_remaining(now + 120).starts_with("expires in 2m"));
+        assert!(format_remaining(now + 7200).starts_with("expires in 2h"));
+    }
+
+    #[test]
+    fn summarize_error_collapses_and_extracts_aadsts() {
+        let verbose = "authentication error: token request returned 400 Bad Request: {\"error\":\"invalid_request\",\"error_description\":\"AADSTS90002: Tenant 'x' not found.\"}";
+        let s = summarize_error(verbose);
+        // Single line.
+        assert!(!s.contains('\n'));
+        // AADSTS code surfaced.
+        assert!(s.contains("AADSTS90002"));
+        // Bounded length (120 chars + code suffix + ellipsis).
+        assert!(s.chars().count() <= 120 + 20);
+    }
+
+    #[test]
+    fn summarize_error_handles_plain_message() {
+        let s = summarize_error("network error: connection refused");
+        assert_eq!(s, "network error: connection refused");
+    }
+
+    #[test]
+    fn describe_access_token_states() {
+        // Present from keychain with future expiry.
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let prov = CredentialProvenance {
+            tenant_id: Resolved {
+                value: None,
+                source: Source::None,
+            },
+            client_id: Resolved {
+                value: None,
+                source: Source::None,
+            },
+            client_secret: Resolved {
+                value: None,
+                source: Source::None,
+            },
+            access_token: Resolved {
+                value: Some("tok".to_string()),
+                source: Source::Keychain("token_bundle"),
+            },
+            refresh_token: Resolved {
+                value: None,
+                source: Source::None,
+            },
+            access_token_expires_at: Some(now + 600),
+            mde_base_url: "https://example.com".to_string(),
+            graph_base_url: "https://example.com".to_string(),
+        };
+        let desc = describe_access_token(&prov);
+        assert!(desc.starts_with("present (expires in"));
+        assert!(!desc.contains("tok"));
+
+        // Expired bundle: no value, but expiry known.
+        let expired = CredentialProvenance {
+            access_token: Resolved {
+                value: None,
+                source: Source::None,
+            },
+            access_token_expires_at: Some(now.saturating_sub(10)),
+            ..prov.clone()
+        };
+        assert_eq!(describe_access_token(&expired), "expired");
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod alerts;
 pub mod auth;
 pub mod credentials;
+pub mod doctor;
 pub mod hunting;
 pub mod incidents;
 pub mod indicators;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -137,6 +137,79 @@ fn load_credentials_file() -> CredentialsFile {
     CredentialsFile::default()
 }
 
+/// Where a resolved credential value came from. Used by `doctor` to show
+/// the provenance of each field without ever printing the value itself.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Source {
+    /// CLI argument (`--tenant-id`, `--client-id`).
+    CliArg,
+    /// Environment variable (e.g. `MDE_CLIENT_SECRET`).
+    Env(&'static str),
+    /// OS credential store (macOS Keychain), with the logical key.
+    Keychain(&'static str),
+    /// credentials.toml.
+    TomlFile,
+    /// No value resolved from any source.
+    None,
+}
+
+impl Source {
+    /// Human-readable provenance label for `doctor` output. Includes the
+    /// Keychain service so the user can locate the entry, but never the value.
+    pub fn label(&self) -> String {
+        match self {
+            Source::CliArg => "cli argument".to_string(),
+            Source::Env(var) => format!("env {}", var),
+            Source::Keychain(key) => {
+                format!("keychain {}/{}", credential_store::SERVICE, key)
+            }
+            Source::TomlFile => "credentials.toml".to_string(),
+            Source::None => "not set".to_string(),
+        }
+    }
+}
+
+/// A resolved credential value paired with the source it came from.
+#[derive(Clone)]
+pub struct Resolved<T> {
+    pub value: Option<T>,
+    pub source: Source,
+}
+
+impl<T> Resolved<T> {
+    fn found(value: T, source: Source) -> Self {
+        Self {
+            value: Some(value),
+            source,
+        }
+    }
+
+    fn none() -> Self {
+        Self {
+            value: None,
+            source: Source::None,
+        }
+    }
+}
+
+/// Provenance-tracked view of resolved credentials, used by `doctor`.
+/// Mirrors the resolution order of [`MdeCredentials::resolve`] but records
+/// which source supplied each field. Values are still held in memory; callers
+/// must mask secrets before display.
+#[derive(Clone)]
+pub struct CredentialProvenance {
+    pub tenant_id: Resolved<String>,
+    pub client_id: Resolved<String>,
+    pub client_secret: Resolved<String>,
+    pub access_token: Resolved<String>,
+    pub refresh_token: Resolved<String>,
+    /// Unix expiry (seconds) of the access token, only known when it came
+    /// from a Keychain TokenBundle.
+    pub access_token_expires_at: Option<u64>,
+    pub mde_base_url: String,
+    pub graph_base_url: String,
+}
+
 /// Resolved MDE credentials collected from CLI args, environment variables,
 /// the OS credential store (e.g. macOS Keychain), and credentials.toml.
 /// Once constructed, the process should unset the MDE_* environment variables so that
@@ -190,6 +263,23 @@ impl Default for MdeCredentials {
     }
 }
 
+/// Drop the provenance metadata, keeping only the resolved values. Lets the
+/// non-diagnostic code paths share the single resolution implementation in
+/// [`MdeCredentials::resolve_with_provenance`].
+impl From<CredentialProvenance> for MdeCredentials {
+    fn from(p: CredentialProvenance) -> Self {
+        Self {
+            tenant_id: p.tenant_id.value,
+            client_id: p.client_id.value,
+            client_secret: p.client_secret.value,
+            access_token: p.access_token.value,
+            refresh_token: p.refresh_token.value,
+            mde_base_url: p.mde_base_url,
+            graph_base_url: p.graph_base_url,
+        }
+    }
+}
+
 impl MdeCredentials {
     /// Resolve credentials from CLI args, environment variables, the OS
     /// credential store, and credentials.toml.
@@ -212,43 +302,84 @@ impl MdeCredentials {
         cli_client_id: Option<&str>,
         store: Option<&dyn CredentialStore>,
     ) -> Self {
+        Self::from(Self::resolve_with_provenance(
+            cli_tenant_id,
+            cli_client_id,
+            store,
+        ))
+    }
+
+    /// Resolve credentials while recording the source of each field.
+    ///
+    /// Uses the exact same priority order as [`Self::resolve_with_store`] so
+    /// that what `doctor` reports matches what the API client actually sees.
+    /// The returned struct still carries the secret values (callers that
+    /// display them, e.g. `doctor`, MUST mask first).
+    pub fn resolve_with_provenance(
+        cli_tenant_id: Option<&str>,
+        cli_client_id: Option<&str>,
+        store: Option<&dyn CredentialStore>,
+    ) -> CredentialProvenance {
         let file = load_credentials_file();
 
-        let tenant_id = cli_tenant_id
-            .map(String::from)
-            .or_else(|| std::env::var("MDE_TENANT_ID").ok())
-            .or(file.tenant_id);
+        let tenant_id = if let Some(v) = cli_tenant_id {
+            Resolved::found(v.to_string(), Source::CliArg)
+        } else if let Ok(v) = std::env::var("MDE_TENANT_ID") {
+            Resolved::found(v, Source::Env("MDE_TENANT_ID"))
+        } else if let Some(v) = file.tenant_id {
+            Resolved::found(v, Source::TomlFile)
+        } else {
+            Resolved::none()
+        };
 
-        let client_id = cli_client_id
-            .map(String::from)
-            .or_else(|| std::env::var("MDE_CLIENT_ID").ok())
-            .or(file.client_id);
+        let client_id = if let Some(v) = cli_client_id {
+            Resolved::found(v.to_string(), Source::CliArg)
+        } else if let Ok(v) = std::env::var("MDE_CLIENT_ID") {
+            Resolved::found(v, Source::Env("MDE_CLIENT_ID"))
+        } else if let Some(v) = file.client_id {
+            Resolved::found(v, Source::TomlFile)
+        } else {
+            Resolved::none()
+        };
 
-        let client_secret = std::env::var("MDE_CLIENT_SECRET").ok().or_else(|| {
+        let client_secret = if let Ok(v) = std::env::var("MDE_CLIENT_SECRET") {
+            Resolved::found(v, Source::Env("MDE_CLIENT_SECRET"))
+        } else {
             match read_secret_from_store(store, KEY_CLIENT_SECRET) {
-                StoreLookup::Found(v) => Some(v),
+                StoreLookup::Found(v) => Resolved::found(v, Source::Keychain(KEY_CLIENT_SECRET)),
                 // Backend failures: do NOT fall back to plaintext toml.
-                // Surface the missing secret to the caller, which will turn
-                // into a "client_secret not set" error from validate().
-                StoreLookup::BackendError => None,
+                StoreLookup::BackendError => Resolved::none(),
                 // Store skipped or empty: fall through to toml.
-                StoreLookup::SkipFallthrough | StoreLookup::NotStored => file.client_secret,
+                StoreLookup::SkipFallthrough | StoreLookup::NotStored => match file.client_secret {
+                    Some(v) => Resolved::found(v, Source::TomlFile),
+                    None => Resolved::none(),
+                },
             }
-        });
+        };
 
         let bundle = resolve_token_bundle(store);
 
-        let access_token = std::env::var("MDE_ACCESS_TOKEN").ok().or_else(|| {
-            bundle.as_ref().and_then(|b| {
+        let (access_token, access_token_expires_at) =
+            if let Ok(v) = std::env::var("MDE_ACCESS_TOKEN") {
+                // Env-supplied token: expiry is unknown to us.
+                (Resolved::found(v, Source::Env("MDE_ACCESS_TOKEN")), None)
+            } else if let Some(b) = bundle.as_ref() {
                 if is_bundle_expired(b) {
-                    None
+                    (Resolved::none(), Some(b.expires_at))
                 } else {
-                    Some(b.access_token.clone())
+                    (
+                        Resolved::found(b.access_token.clone(), Source::Keychain(KEY_TOKEN_BUNDLE)),
+                        Some(b.expires_at),
+                    )
                 }
-            })
-        });
+            } else {
+                (Resolved::none(), None)
+            };
 
-        let refresh_token = bundle.as_ref().and_then(|b| b.refresh_token.clone());
+        let refresh_token = match bundle.as_ref().and_then(|b| b.refresh_token.clone()) {
+            Some(v) => Resolved::found(v, Source::Keychain(KEY_TOKEN_BUNDLE)),
+            None => Resolved::none(),
+        };
 
         let mde_base_url = file
             .mde_base_url
@@ -258,12 +389,13 @@ impl MdeCredentials {
             .graph_base_url
             .unwrap_or_else(|| DEFAULT_GRAPH_BASE_URL.to_string());
 
-        Self {
+        CredentialProvenance {
             tenant_id,
             client_id,
             client_secret,
             access_token,
             refresh_token,
+            access_token_expires_at,
             mde_base_url,
             graph_base_url,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,15 +64,18 @@ fn main() {
     load_dotenv_excluding_mde_keys();
     let cli = Cli::parse();
 
-    // For subcommands that do not talk to the API (`credentials`,
-    // `completion`), skip resolve() entirely. resolve() may consult the
-    // OS credential store, which can prompt or fail with an ACL error;
-    // letting that noise leak into a `credentials status` invocation
-    // confuses the user — the whole point of `credentials status` is to
-    // tell them about the store, not to be polluted by it.
+    // For subcommands that do not talk to the API via the normal client
+    // path (`credentials`, `completion`, `doctor`), skip resolve() and the
+    // env scrub. resolve() may consult the OS credential store, which can
+    // prompt or fail with an ACL error; letting that noise leak into a
+    // `credentials status` invocation confuses the user. `doctor` resolves
+    // credentials itself (with provenance tracking) and reads MDE_* env
+    // vars directly, so it must run before the env scrub.
     if matches!(
         cli.command,
-        Some(Commands::Credentials { .. }) | Some(Commands::Completion { .. })
+        Some(Commands::Credentials { .. })
+            | Some(Commands::Completion { .. })
+            | Some(Commands::Doctor)
     ) {
         let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
         rt.block_on(async {
@@ -182,6 +185,21 @@ async fn run(cli: Cli, mut credentials: MdeCredentials) -> Result<(), AppError> 
         let bin_name = cmd.get_name().to_string();
         generate(*shell, &mut cmd, bin_name, &mut io::stdout());
         return Ok(());
+    }
+
+    // Handle doctor diagnostics. doctor resolves credentials itself (with
+    // provenance) and never routes through the agent; it reports on the
+    // local config/credentials/environment and probes connectivity.
+    //
+    // We deliberately do NOT forward cli.tenant_id / cli.client_id here.
+    // clap folds the `--tenant-id` flag and the `MDE_TENANT_ID` env var into
+    // the same field, so a forwarded value could not be attributed to its
+    // real source. doctor reads the environment itself to report an accurate
+    // provenance (env vs credentials.toml). The trade-off: a value supplied
+    // *only* via the `--tenant-id` flag (no env, no toml) is not reflected —
+    // an uncommon case for a diagnostic invocation.
+    if let Commands::Doctor = &command {
+        return mde::commands::doctor::handle().await;
     }
 
     // Handle credentials store management (does not require API credentials).
@@ -460,6 +478,7 @@ fn requires_agent_routing(command: &Commands) -> bool {
         Commands::Auth { command } => command.is_some(),
         Commands::Agent { .. } => false, // agent commands are handled separately
         Commands::Credentials { .. } => false, // handled locally
+        Commands::Doctor => false,       // handled locally
         Commands::Completion { .. } => false, // handled locally
     }
 }


### PR DESCRIPTION
## What

Add a `doctor` subcommand that prints a one-screen diagnostic of the local
setup: the active config file, the effective credentials **and where each one
resolved from**, the state of the `MDE_*` environment variables, and a live
connectivity probe. Modeled on `jamf-cli doctor`.

```text
mde-cli 0.13.0

CONFIG
  path:    /Users/you/.config/mde/credentials.toml
  status:  present

ACTIVE CREDENTIALS
  tenant-id:      11111111-2222-3333-...       (source: env MDE_TENANT_ID)
  client-id:      abcd****                     (source: credentials.toml)
  client-secret:  present                      (source: keychain dev.mde-cli/client_secret)
  access-token:   present (expires in 42m)     (source: keychain dev.mde-cli/token_bundle)
  refresh-token:  present                      (source: keychain dev.mde-cli/token_bundle)
  mde-base-url:   https://api.security.microsoft.com
  graph-base-url: https://graph.microsoft.com

ENVIRONMENT
  MDE_TENANT_ID          (set)
  MDE_CLIENT_SECRET      (set, hidden)
  ...

CONNECTIVITY
  GET https://api.security.microsoft.com/api/machines?$top=1  ->  200 OK (243ms)
```

## Why

Credential resolution in `mde-cli` draws from four sources (CLI args, env
vars, the macOS Keychain, and `credentials.toml`) with a defined priority
order. When a command fails to authenticate, the user has no quick way to see
*which* source actually supplied a value, whether the Keychain entry exists,
or whether the API is even reachable. `doctor` answers all of that in one
command so troubleshooting starts here instead of with guesswork.

The existing `credentials status` only inspects the Keychain; `doctor`
subsumes that with a credentials-wide, source-aware view.

## How

- **Provenance tracking** (`config`): a new `resolve_with_provenance` mirrors
  the existing resolution order but records a `Source` per field.
  `resolve_with_store` now delegates to it and drops the metadata, so there is
  a single resolution implementation and the non-diagnostic paths are
  unchanged.
- **Secrets are never printed.** `client_secret` / `access_token` /
  `refresh_token` are reported by presence and source only; `client_id` is
  masked to its first 4 characters; secret-bearing env vars show
  `(set, hidden)`. `CredentialProvenance` intentionally does not derive
  `Debug`.
- **Connectivity probe** reuses the existing client to `GET
  /api/machines?$top=1`, printing only the HTTP status and elapsed time — a
  `401`/`403` still confirms the service was reached. The probe is `skipped`
  when no credentials are available, and verbose token-endpoint errors are
  collapsed to a single line with any `AADSTS` code extracted.
- Wired in `main.rs` before the env scrub (alongside `credentials` /
  `completion`); does not route through the agent. It does not forward
  `--tenant-id` / `--client-id` because clap merges those flags with their env
  vars, which would misattribute the reported source.

## Notes

- Tests: 112 passed (unit + integration), `clippy` clean, `fmt` clean.
- Reviewed by subagents for diff correctness and secret-leak safety: no
  findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
