### PR TITLE
chore: bump version to 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "defender-for-endpoint-cli"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "arboard",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "defender-for-endpoint-cli"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 description = "CLI tool for Microsoft Defender for Endpoint API"
 license = "MIT"


### PR DESCRIPTION
## What

Bump the crate version from 0.13.0 to 0.14.0.

## Why

Cut a release that includes the `doctor` diagnostic subcommand (#92). Per
semver this is a minor bump: a new user-facing command was added with no
breaking changes.

## How

Updated `version` in `Cargo.toml` and regenerated `Cargo.lock`. Tagging
`v0.14.0` on `main` after this merges triggers the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)